### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/JohnCCarter/Genesis-Core/security/code-scanning/1](https://github.com/JohnCCarter/Genesis-Core/security/code-scanning/1)

To fix this problem, add a `permissions` block that specifies minimal necessary privileges. The most restrictive and generally recommended permission for CI jobs that only check out the code and run tests/lints is `contents: read`. This can be added either at the top level of the workflow or inside the specific job. Since there is only one job and no indication that job-specific permissions are needed, it is preferable to add it at the workflow level (directly below the `name` block and before `on:`). This restricts the GITHUB_TOKEN permissions for the entire workflow and adheres to the least privilege principle. No additional dependencies or code changes outside `.github/workflows/ci.yml` are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Sammanfattning av Sourcery

CI:
- Begränsa GITHUB_TOKEN till skrivskyddad behörighet för innehåll i CI-arbetsflödet för att åtgärda en avisering från kodskanning

<details>
<summary>Original summary in English</summary>

## Sammanfattning av Sourcery

Förbättringar:
- Lägg till ett behörighetsblock på arbetsflödesnivå i .github/workflows/ci.yml för att ställa in contents: read för GITHUB_TOKEN

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Add a permissions block at the workflow level in .github/workflows/ci.yml to set contents: read for the GITHUB_TOKEN

</details>

</details>