### PR TITLE
Always mask sensitive headers to resolve CodeQL alert

### DIFF
--- a/scripts/build_auth_headers.py
+++ b/scripts/build_auth_headers.py
@@ -58,7 +58,10 @@ def main(argv: list[str] | None = None) -> int:
 
     # Always mask sensitive fields to avoid clear-text logging (resolves CodeQL alert)
     out = {
-        key: ("***" if key in {"bfx-apikey", "bfx-signature"} else value)
+        key: (
+            "***" if key == "bfx-apikey"
+            else (value[:6] + "..." if key == "bfx-signature" else value)
+        )
         for key, value in headers.items()
     }
 


### PR DESCRIPTION
Här är en översättning av pull request-sammanfattningen till svenska:

## Sammanfattning av Sourcery

Inför maskering av känsliga rubriker i skriptet för autentiseringsrubriker för att lösa CodeQL-varningar och markera --mask-flaggan som föråldrad.

Bugfixar:
- Maskera alltid API-nyckel och signatur i utdata från `build_auth_headers` för att förhindra loggning i klartext.

Förbättringar:
- Markera `--mask`-flaggan som föråldrad och förtydliga dess hjälptext.
- Rensa upp tomma rader i skriptet.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce masking of sensitive headers in the auth headers script to resolve CodeQL alerts and update the --mask flag to be deprecated

Bug Fixes:
- Always mask API key and signature in build_auth_headers output to prevent clear-text logging

Enhancements:
- Deprecate the --mask flag and clarify its help text
- Clean up blank lines in the script

</details>