### PR TITLE
fix(strategy-family): resolve post-merge review comments

### DIFF
--- a/scripts/validate/validate_optimizer_config.py
+++ b/scripts/validate/validate_optimizer_config.py
@@ -107,6 +107,11 @@ def _get_param_spec(params_spec: dict[str, Any], path: str) -> dict[str, Any] | 
     return current if isinstance(current, dict) else None
 
 
+def _get_parameters_mapping(opt_cfg: dict[str, Any]) -> dict[str, Any] | None:
+    params_spec = opt_cfg.get("parameters", {})
+    return params_spec if isinstance(params_spec, dict) else None
+
+
 def _spec_allows_value(spec: dict[str, Any] | None, expected: Any) -> bool:
     if not isinstance(spec, dict):
         return False
@@ -173,8 +178,8 @@ def validate_optimizer_strategy_family(opt_cfg: dict[str, Any]) -> tuple[list[st
             errors.append("[ERROR] strategy_family måste vara 'legacy' eller 'ri'")
         return errors, warnings
 
-    params_spec = opt_cfg.get("parameters", {})
-    if not isinstance(params_spec, dict):
+    params_spec = _get_parameters_mapping(opt_cfg)
+    if params_spec is None:
         errors.append("[ERROR] parameters måste vara en dict/mapping i optimizer-konfig")
         return errors, warnings
 
@@ -235,7 +240,9 @@ def check_fixed_matches_champion(
 ) -> list[str]:
     """Kontrollera om fixerad parameter matchar champion."""
     errors = []
-    params_spec = opt_cfg.get("parameters", {})
+    params_spec = _get_parameters_mapping(opt_cfg)
+    if params_spec is None:
+        return ["[WARN] parameters måste vara en dict/mapping i optimizer-konfig"]
 
     # Navigera till parameter-specen
     keys = param_path.split(".")
@@ -271,7 +278,9 @@ def check_champion_in_range(
 ) -> list[str]:
     """Kontrollera om championens värde ligger i sökrymden."""
     errors = []
-    params_spec = opt_cfg.get("parameters", {})
+    params_spec = _get_parameters_mapping(opt_cfg)
+    if params_spec is None:
+        return ["[WARN] parameters måste vara en dict/mapping i optimizer-konfig"]
 
     # Navigera till parameter-specen
     keys = param_path.split(".")
@@ -326,7 +335,11 @@ def validate_risk_map_deltas(
     errors.extend(family_errors)
     warnings.extend(family_warnings)
 
-    risk_spec = opt_cfg.get("parameters", {}).get("risk", {})
+    params_spec = _get_parameters_mapping(opt_cfg)
+    if params_spec is None:
+        return errors, warnings
+
+    risk_spec = params_spec.get("risk", {})
     deltas_spec = risk_spec.get("risk_map_deltas")
     if not isinstance(deltas_spec, dict):
         warnings.append(
@@ -510,7 +523,7 @@ def validate_config(opt_config_path: Path) -> int:
 
     # Kontrollera signal_adaptation (saknas ofta i Optuna-konfigs)
     champ_signal_adapt = extract_param_value(champ_params, "thresholds.signal_adaptation")
-    opt_params = opt_cfg.get("parameters", {})
+    opt_params = _get_parameters_mapping(opt_cfg) or {}
     opt_signal_adapt = extract_param_value(opt_params, "thresholds.signal_adaptation")
 
     if champ_signal_adapt and not opt_signal_adapt:

--- a/src/core/config/authority.py
+++ b/src/core/config/authority.py
@@ -21,6 +21,14 @@ from core.utils.logging_redaction import get_logger
 
 _LOGGER = get_logger(__name__)
 
+_MISSING_STRATEGY_FAMILY_BACKCOMPAT_MSG = (
+    "missing_strategy_family_backcompat_requires_legacy_signature"
+)
+
+
+class _MissingStrategyFamilyBackcompatError(Exception):
+    """Internal control-flow marker for legacy-only strategy_family backcompat."""
+
 
 def _resolve_repo_root() -> Path:
     """Resolve repo root deterministically from this module's location.
@@ -58,6 +66,12 @@ def _canonicalize_authority_mode_alias(patch: dict[str, Any]) -> dict[str, Any]:
     return canonicalize_authority_mode_alias_strict(patch)
 
 
+def _raise_missing_strategy_family_backcompat_error() -> None:
+    raise _MissingStrategyFamilyBackcompatError(
+        _MISSING_STRATEGY_FAMILY_BACKCOMPAT_MSG,
+    )
+
+
 def _normalize_loaded_runtime_cfg(cfg: dict[str, Any]) -> dict[str, Any]:
     normalized = dict(cfg or {})
     if normalized.get("strategy_family") is not None:
@@ -65,9 +79,11 @@ def _normalize_loaded_runtime_cfg(cfg: dict[str, Any]) -> dict[str, Any]:
     try:
         inferred_family = classify_strategy_family(normalized)
     except StrategyFamilyValidationError as exc:
-        raise ValueError("missing_strategy_family_backcompat_requires_legacy_signature") from exc
+        raise _MissingStrategyFamilyBackcompatError(
+            _MISSING_STRATEGY_FAMILY_BACKCOMPAT_MSG,
+        ) from exc
     if inferred_family != STRATEGY_FAMILY_LEGACY:
-        raise ValueError("missing_strategy_family_backcompat_requires_legacy_signature")
+        _raise_missing_strategy_family_backcompat_error()
     normalized["strategy_family"] = STRATEGY_FAMILY_LEGACY
     return normalized
 
@@ -88,9 +104,9 @@ class ConfigAuthority:
                     cfg_raw = _normalize_loaded_runtime_cfg(data.get("cfg") or {})
                     _ = RuntimeConfig(**cfg_raw)  # validera
                     return v, cfg_raw
+                except _MissingStrategyFamilyBackcompatError as e:
+                    raise ValueError(_MISSING_STRATEGY_FAMILY_BACKCOMPAT_MSG) from e
                 except ValueError as e:
-                    if str(e) == "missing_strategy_family_backcompat_requires_legacy_signature":
-                        raise
                     _LOGGER.debug("seed_read_error: %s", e)
                 except Exception as e:
                     _LOGGER.debug("seed_read_error: %s", e)
@@ -110,7 +126,10 @@ class ConfigAuthority:
 
     def load(self) -> RuntimeSnapshot:
         version, cfg_raw = self._read()
-        cfg_raw = _normalize_loaded_runtime_cfg(cfg_raw)
+        try:
+            cfg_raw = _normalize_loaded_runtime_cfg(cfg_raw)
+        except _MissingStrategyFamilyBackcompatError as exc:
+            raise ValueError(_MISSING_STRATEGY_FAMILY_BACKCOMPAT_MSG) from exc
         cfg = RuntimeConfig(**cfg_raw)
         cfg_canon = cfg.model_dump_canonical()
         h = self._hash_cfg(cfg_canon)

--- a/src/core/intelligence/ledger_adapter/processing.py
+++ b/src/core/intelligence/ledger_adapter/processing.py
@@ -99,7 +99,9 @@ class DeterministicIntelligenceLedgerAdapter(IntelligenceLedgerAdapter):
             try:
                 resolved_strategy_family = resolve_strategy_family(dict(self.strategy_config or {}))
             except StrategyFamilyValidationError as exc:
-                raise ValueError("strategy_family_context_required") from exc
+                if str(exc) == "missing_strategy_family":
+                    raise ValueError("strategy_family_context_required") from exc
+                raise
 
         persisted_event_ids: list[str] = []
         ledger_entity_ids: list[str] = []

--- a/src/core/research_ledger/service.py
+++ b/src/core/research_ledger/service.py
@@ -26,6 +26,7 @@ from core.strategy.family_registry import (
     StrategyFamilyValidationError,
     classify_strategy_family,
     resolve_strategy_family,
+    validate_strategy_family_config,
     validate_strategy_family_name,
 )
 
@@ -87,16 +88,17 @@ class ResearchLedgerService:
         explicit_family = (
             validate_strategy_family_name(strategy_family) if strategy_family is not None else None
         )
+        normalized_config = dict(config or {})
         if explicit_family is not None and config is not None:
             config_family = (
-                validate_strategy_family_name(config.get("strategy_family"))
-                if config.get("strategy_family") is not None
-                else classify_strategy_family(dict(config or {}))
+                validate_strategy_family_config(normalized_config)
+                if normalized_config.get("strategy_family") is not None
+                else classify_strategy_family(normalized_config)
             )
             if config_family != explicit_family:
                 raise StrategyFamilyValidationError("strategy_family_config_mismatch")
 
-        resolved_family = explicit_family or resolve_strategy_family(dict(config or {}))
+        resolved_family = explicit_family or resolve_strategy_family(normalized_config)
         tagged_metadata = dict(record.metadata)
         tagged_metadata["strategy_family"] = resolved_family
         tagged_metadata["strategy_family_source"] = strategy_family_source

--- a/tests/core/research_ledger/test_service.py
+++ b/tests/core/research_ledger/test_service.py
@@ -204,6 +204,79 @@ def test_append_record_with_strategy_family_rejects_config_family_mismatch(tmp_p
         )
 
 
+def test_append_record_with_strategy_family_accepts_semantically_valid_declared_config(
+    tmp_path: Path,
+) -> None:
+    service = _service(tmp_path)
+    hypothesis = HypothesisRecord(
+        entity_id="HYP-2026-0011",
+        entity_type=LedgerEntityType.HYPOTHESIS,
+        created_at="2026-03-18T16:06:00+00:00",
+        title="Valid RI hypothesis",
+        hypothesis="Explicit family should accept semantically valid matching config.",
+    )
+
+    appended = service.append_record_with_strategy_family(
+        hypothesis,
+        config={
+            "strategy_family": "ri",
+            "thresholds": {
+                "entry_conf_overall": 0.25,
+                "regime_proba": {"balanced": 0.36},
+                "signal_adaptation": {
+                    "atr_period": 14,
+                    "zones": {
+                        "low": {"entry_conf_overall": 0.16, "regime_proba": 0.33},
+                        "mid": {"entry_conf_overall": 0.40, "regime_proba": 0.51},
+                        "high": {"entry_conf_overall": 0.32, "regime_proba": 0.57},
+                    },
+                },
+            },
+            "gates": {"hysteresis_steps": 3, "cooldown_bars": 2},
+            "multi_timeframe": {"regime_intelligence": {"authority_mode": "regime_module"}},
+        },
+        strategy_family="ri",
+    )
+
+    assert appended.metadata["strategy_family"] == "ri"
+
+
+def test_append_record_with_strategy_family_rejects_semantically_invalid_declared_config(
+    tmp_path: Path,
+) -> None:
+    service = _service(tmp_path)
+    hypothesis = HypothesisRecord(
+        entity_id="HYP-2026-0012",
+        entity_type=LedgerEntityType.HYPOTHESIS,
+        created_at="2026-03-18T16:07:00+00:00",
+        title="Invalid RI hypothesis",
+        hypothesis="Explicit family should reject invalid declared RI configs.",
+    )
+
+    with pytest.raises(StrategyFamilyValidationError, match="ri_requires_canonical_gates"):
+        service.append_record_with_strategy_family(
+            hypothesis,
+            config={
+                "strategy_family": "ri",
+                "thresholds": {
+                    "entry_conf_overall": 0.25,
+                    "regime_proba": {"balanced": 0.36},
+                    "signal_adaptation": {
+                        "atr_period": 14,
+                        "zones": {
+                            "low": {"entry_conf_overall": 0.16, "regime_proba": 0.33},
+                            "mid": {"entry_conf_overall": 0.40, "regime_proba": 0.51},
+                            "high": {"entry_conf_overall": 0.32, "regime_proba": 0.57},
+                        },
+                    },
+                },
+                "gates": {"hysteresis_steps": 2, "cooldown_bars": 0},
+                "multi_timeframe": {"regime_intelligence": {"authority_mode": "regime_module"}},
+            },
+            strategy_family="ri",
+        )
+
+
 def test_allocate_id_is_storage_state_deterministic(tmp_path: Path) -> None:
     service = _service(tmp_path)
 

--- a/tests/intelligence/test_ledger_adapter_processing.py
+++ b/tests/intelligence/test_ledger_adapter_processing.py
@@ -18,6 +18,7 @@ from core.intelligence.ledger_adapter import (
 from core.research_ledger import ArtifactKind, LedgerEntityType, ResearchLedgerService
 from core.research_ledger.models import record_to_dict
 from core.research_ledger.storage import LedgerStorage
+from core.strategy.family_registry import StrategyFamilyValidationError
 
 
 def _event(index: int, *, source: str = "regime_intelligence") -> IntelligenceEvent:
@@ -145,6 +146,35 @@ def test_persist_events_fails_fast_without_strategy_family_context(tmp_path: Pat
     adapter = DeterministicIntelligenceLedgerAdapter(service=service)
 
     with pytest.raises(ValueError, match="strategy_family_context_required"):
+        adapter.persist_events(LedgerPersistenceRequest(events=(_validated_event(1),)))
+
+    assert service.storage.list_records(LedgerEntityType.ARTIFACT) == []
+
+
+def test_persist_events_preserves_invalid_strategy_family_errors(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    adapter = DeterministicIntelligenceLedgerAdapter(
+        service=service,
+        strategy_config={
+            "strategy_family": "ri",
+            "thresholds": {
+                "entry_conf_overall": 0.25,
+                "regime_proba": {"balanced": 0.36},
+                "signal_adaptation": {
+                    "atr_period": 14,
+                    "zones": {
+                        "low": {"entry_conf_overall": 0.16, "regime_proba": 0.33},
+                        "mid": {"entry_conf_overall": 0.40, "regime_proba": 0.51},
+                        "high": {"entry_conf_overall": 0.32, "regime_proba": 0.57},
+                    },
+                },
+            },
+            "gates": {"hysteresis_steps": 2, "cooldown_bars": 0},
+            "multi_timeframe": {"regime_intelligence": {"authority_mode": "regime_module"}},
+        },
+    )
+
+    with pytest.raises(StrategyFamilyValidationError, match="ri_requires_canonical_gates"):
         adapter.persist_events(LedgerPersistenceRequest(events=(_validated_event(1),)))
 
     assert service.storage.list_records(LedgerEntityType.ARTIFACT) == []

--- a/tests/utils/test_preflight_optuna_check.py
+++ b/tests/utils/test_preflight_optuna_check.py
@@ -299,3 +299,64 @@ parameters: {}
     # Kör som CLI.
     monkeypatch.setattr(sys, "argv", ["preflight_optuna_check.py", str(cfg_path)])
     assert preflight.main() == 1
+
+
+def test_main_fails_when_champion_validation_returns_non_zero(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    from scripts.preflight import preflight_optuna_check as preflight
+
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(
+        """
+meta:
+    runs:
+        optuna:
+            timeout_seconds: 10
+parameters: {}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(preflight, "maybe_load_dotenv", lambda: (True, "[OK]"))
+    monkeypatch.setattr(preflight, "check_optuna_installed", lambda: (True, "[OK]"))
+    monkeypatch.setattr(
+        preflight, "check_storage_writable", lambda *_args, **_kwargs: (True, "[OK]")
+    )
+    monkeypatch.setattr(preflight, "check_study_resume", lambda *_args, **_kwargs: (True, "[OK]"))
+    monkeypatch.setattr(
+        preflight, "check_sampler_settings", lambda *_args, **_kwargs: (True, "[OK]")
+    )
+    monkeypatch.setattr(preflight, "check_duplicate_guard", lambda: (True, "[OK]"))
+    monkeypatch.setattr(preflight, "check_timeout_config", lambda *_args, **_kwargs: (True, "[OK]"))
+    monkeypatch.setattr(preflight, "check_mode_flags_consistency", lambda: (True, "[OK]"))
+    monkeypatch.setattr(
+        preflight, "check_storage_resume_sanity", lambda *_args, **_kwargs: (True, "[OK]")
+    )
+    monkeypatch.setattr(
+        preflight, "check_parameters_valid", lambda *_args, **_kwargs: (True, "[OK]")
+    )
+    monkeypatch.setattr(
+        preflight, "check_snapshot_exists", lambda *_args, **_kwargs: (True, "[OK]")
+    )
+    monkeypatch.setattr(
+        preflight, "check_htf_requirements", lambda *_args, **_kwargs: (True, "[OK]")
+    )
+    monkeypatch.setattr(preflight, "check_date_source", lambda *_args, **_kwargs: (True, "[OK]"))
+    monkeypatch.setattr(
+        preflight, "check_requested_data_coverage", lambda *_args, **_kwargs: (True, "[OK]")
+    )
+    monkeypatch.setattr(
+        preflight, "check_champion_drift_smoke", lambda *_args, **_kwargs: (True, "[OK]")
+    )
+    monkeypatch.setattr(
+        preflight, "check_precompute_functionality", lambda *_args, **_kwargs: (True, "[OK]")
+    )
+
+    stub = types.ModuleType("scripts.validate.validate_optimizer_config")
+    stub.validate_config = lambda *_args, **_kwargs: 1  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "scripts.validate.validate_optimizer_config", stub)
+
+    monkeypatch.setattr(sys, "argv", ["preflight_optuna_check.py", str(cfg_path)])
+    assert preflight.main() == 1

--- a/tests/utils/test_validate_optimizer_config.py
+++ b/tests/utils/test_validate_optimizer_config.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import textwrap
+
+import scripts.validate.validate_optimizer_config as validate_optimizer_config_module
 from scripts.validate.validate_optimizer_config import (
     normalize_champion_payload,
+    validate_config,
     validate_optimizer_strategy_family,
 )
 
@@ -160,3 +164,25 @@ def test_validate_optimizer_strategy_family_rejects_non_mapping_parameters() -> 
     errors, _warnings = validate_optimizer_strategy_family(opt_cfg)
 
     assert any("parameters måste vara en dict/mapping" in error for error in errors)
+
+
+def test_validate_config_rejects_non_mapping_parameters_without_crashing(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    cfg_path = tmp_path / "bad_optimizer.yaml"
+    cfg_path.write_text(
+        textwrap.dedent(
+            """
+            meta:
+              symbol: tBTCUSD
+              timeframe: 1h
+            strategy_family: legacy
+            parameters: []
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(validate_optimizer_config_module, "load_champion", lambda *_args: {})
+
+    assert validate_config(cfg_path) == 1


### PR DESCRIPTION
## Summary
- resolve the remaining post-merge review comments around strategy-family validation and error semantics
- harden optimizer validation so malformed `parameters` fail deterministically instead of crashing
- preserve specific strategy-family validation errors for invalid configs while keeping missing-context behavior intact

## Verification
- C:/Users/fa06662/Projects/Genesis-Core/.venv/Scripts/python.exe -m pytest tests/governance/test_config_schema_backcompat.py tests/utils/test_validate_optimizer_config.py tests/core/research_ledger/test_service.py tests/intelligence/test_ledger_adapter_processing.py tests/utils/test_preflight_optuna_check.py tests/core/strategy/test_families.py tests/governance/test_config_ssot.py::test_regime_unified_alias_only_is_canonicalized_before_persist tests/governance/test_config_ssot.py::test_regime_unified_alias_non_dict_is_rejected tests/governance/test_config_ssot.py::test_regime_unified_alias_extra_key_is_rejected tests/integration/test_config_api_e2e.py::test_runtime_endpoints_e2e_regime_unified_alias_bridge -q
- pre-commit run --all-files
- C:/Users/fa06662/Projects/Genesis-Core/.venv/Scripts/python.exe -m pytest tests/backtest/test_backtest_determinism_smoke.py tests/utils/test_features_asof_cache.py tests/utils/test_features_asof_cache_key_deterministic.py tests/governance/test_pipeline_fast_hash_guard.py::test_pipeline_component_order_hash_contract_is_stable -q
- C:/Users/fa06662/Projects/Genesis-Core/.venv/Scripts/python.exe -m pytest -q
- C:/Users/fa06662/Projects/Genesis-Core/.venv/Scripts/python.exe -m bandit -r src -c bandit.yaml -f txt -o bandit-report.txt

## Summary by Sourcery

Skärp hanteringen av strategy-family och semantiken för optimerarvalidering för att göra konfigurationsfel deterministiska och bevara meningsfull felpropagering mellan research ledger, intelligence-adapter och CLI-preflightkontroller.

Bug Fixes:
- Säkerställ att research ledger och intelligence-adapter exponerar specifika StrategyFamilyValidationError-fall för ogiltiga RI-konfigurationer, samtidigt som beteendet för saknat sammanhang fortsatt mappar till ett stabilt ValueError.
- Förhindra att `validate_optimizer_config` kraschar när optimizer-parametrar inte är en mapping, genom att istället returnera deterministiska fel-/varningskoder.
- Normalisera inläsning av runtime-konfiguration så att backcompat för saknad strategy-family använder ett internt kontrollflödesundantag och konsekvent exponerar ett stabilt ValueError-meddelande externt.

Enhancements:
- Utöka research ledger strategy-family-API:t så att deklarerade konfigurationer valideras när en strategy-family anges explicit och mismatch-detektering upprätthålls.
- Justera intelligence ledger-adaptern så att den endast översätter fel om saknad strategy-family till context-required-fel, medan andra valideringsfel får bubbla vidare oförändrade.
- Extrahera gemensam logik för att hämta optimizer-parameter-mapping till en central funktion för att centralisera typkontroller och förenkla nedströms valideringslogik.

Tests:
- Lägg till research ledger-tester som täcker acceptans och avvisning av semantiskt giltiga och ogiltiga RI-konfigurationer när en strategy-family är deklarerad explicit.
- Lägg till tester för intelligence-adaptern som verifierar att ogiltiga strategy-family-konfigurationer kastar StrategyFamilyValidationError och inte persisterar artefakter.
- Lägg till preflight Optuna-checktest som säkerställer att icke-noll exitkoder från optimizer-config-validering gör att CLI:t misslyckas.
- Lägg till test för optimizer-validering som bekräftar att konfigurationer där parametrar inte är en mapping avvisas med en icke-noll exitkod i stället för att orsaka krasch.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten strategy-family handling and optimizer validation semantics to make configuration errors deterministic and preserve meaningful error propagation across research ledger, intelligence adapter, and CLI preflight checks.

Bug Fixes:
- Ensure research ledger and intelligence adapter surface specific StrategyFamilyValidationError cases for invalid RI configs while keeping missing-context behavior mapped to a stable ValueError.
- Prevent validate_optimizer_config from crashing when optimizer parameters is not a mapping, returning deterministic error/warning codes instead.
- Normalize runtime configuration loading so missing-strategy-family backcompat uses an internal control-flow exception and consistently exposes a stable ValueError message externally.

Enhancements:
- Extend research ledger strategy-family API to validate declared configs when a strategy family is explicitly provided and enforce mismatch detection.
- Adjust intelligence ledger adapter to only translate missing-strategy-family errors into context-required failures while letting other validation errors bubble through unchanged.
- Factor out shared optimizer parameter-mapping extraction to centralize type checks and simplify downstream validation logic.

Tests:
- Add research ledger tests covering acceptance and rejection of semantically valid and invalid RI configs when a strategy family is explicitly declared.
- Add intelligence adapter tests verifying invalid strategy-family configs raise StrategyFamilyValidationError and do not persist artifacts.
- Add preflight Optuna check test ensuring non-zero optimizer-config validation exit codes cause the CLI to fail.
- Add optimizer-validation test confirming non-mapping parameters configurations are rejected with a non-zero exit code instead of crashing.

</details>