### PR TITLE
Feature/premortem closeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,11 @@ Se `docs/features/FEATURE_COMPUTATION_MODES.md` för detaljer, inkl. `GENESIS_MO
 - Runtime config lagras i `config/runtime.json` (SSOT). Filen ignoreras av git; `config/runtime.seed.json` används som seed.
 - API:
   - `GET /config/runtime` → `{ cfg, version, hash }`
-  - `POST /config/runtime/validate` → `{ valid, errors, cfg? }`
-  - `POST /config/runtime/propose` (kräver Bearer) → `{ cfg, version, hash }`
+  - `POST /config/runtime/validate` → `{ valid, errors, cfg? }` — validerar payload mot runtime-schemat; `valid=true` betyder inte i sig att fältet är live-skrivbart
+  - `POST /config/runtime/propose` (kräver Bearer) → `{ cfg, version, hash }` — patchar endast allowlistade live-update-fält via den guardade propose-pathen och använder `expected_version` för optimistic locking
 - Bearer‑auth: sätt env `BEARER_TOKEN` i backend. Skicka `Authorization: Bearer <token>` i UI/klient.
 - Audit: ändringar loggas i `logs/config_audit.jsonl` (rotation vid ~5MB). Innehåller `actor`, `paths`, `hash_before/after`.
+- Aktuell current-state-matris för schema-valid vs live-skrivbar runtime-config finns i `docs/governance/runtime_config_live_update_matrix_2026-05-15.md`.
 
 ## Registry governance (skills/compacts) – repo som SSOT
 

--- a/config/README.md
+++ b/config/README.md
@@ -11,6 +11,15 @@ Detta är en snabb karta över vad som faktiskt används i dagens körvägar.
 - `config/strategy/champions/`
   - Champion-konfigurationer per symbol/tidsram (konsumeras av pipeline).
 
+## Runtime live-update boundary
+
+- `config/runtime.json` är runtime-SSOT på disk.
+- `POST /config/runtime/validate` validerar payload mot `RuntimeConfig`, men avgör **inte** om fältet får skrivas live via config-API:t.
+- `POST /config/runtime/propose` är den guardade live-write-pathen och accepterar bara allowlistade patchytor.
+- Nuvarande live-skrivbara toppytor är `strategy_family`, `thresholds`, `gates`, `risk` (endast `risk_map`), `ev` (endast `R_default`) och utvalda `multi_timeframe`-underytor.
+- Ytor som `exit`, `warmup_bars`, `features`, `htf_exit_config`, `htf_fib` och `ltf_fib` är deklarerade i runtime-schemat men är för närvarande **inte** live-skrivbara via propose-pathen.
+- För exakt current-state-matris, se `docs/governance/runtime_config_live_update_matrix_2026-05-15.md`.
+
 ## Används av scripts/verktyg (inte trading-pipeline)
 
 - `config/champion_weights.json`

--- a/docs/analysis/diagnostics/premortem_followup_phase_plan_2026-05-15.md
+++ b/docs/analysis/diagnostics/premortem_followup_phase_plan_2026-05-15.md
@@ -1,0 +1,203 @@
+# Premortem follow-up phase plan
+
+Date: 2026-05-15
+Branch: `feature/editor-worker-orchestrator`
+Status: `docs-only / planning + phase-1 kickoff / non-executable / no runtime authority`
+
+> Current status note:
+>
+> - This plan translates `artifacts/diagnostics/genesis_core_premortem_2026-05-15.md` into a small sequence of bounded follow-up slices.
+> - It does **not** authorize `src/**`, `tests/**`, `config/**`, `scripts/**`, `results/**`, `artifacts/**`, paper/live, promotion, champion, or runtime-default changes.
+> - Later sensitive phases still require their own commit contract, packet, and stricter review where applicable.
+
+> Later progress note:
+>
+> - Phases 1-3 in this plan have since been landed as docs/governance surfaces.
+> - The phase-4 `decision_gates.py` finite-numeric candidate has since been implemented in a separate bounded runtime slice limited to `src/core/strategy/decision_gates.py` and `tests/utils/test_decision.py`.
+> - The phase-4 EVGate non-finite hardening candidate has since been implemented in a separate bounded runtime slice limited to `src/core/strategy/components/ev_gate.py` and `tests/core/strategy/components/test_ev_gate_integration.py`.
+> - The phase-4 config-authority API-alignment candidate has since been implemented in a separate bounded slice limited to `src/core/api/config.py`, `tests/integration/test_config_endpoints.py`, and `tests/integration/test_config_api_e2e.py`.
+> - The phase-4 reproducibility closeout candidate has since been implemented in a separate bounded evidence slice limited to `scripts/analyze/execution_proxy_evidence.py` and `tests/backtest/test_execution_proxy_evidence.py`.
+> - The bounded candidate set selected by this plan has now been completed; any further premortem follow-up should be opened as new slices rather than treated as unfinished work from this phase plan.
+> - That later implementation slice was separately reviewed and verified; this planning note remains the original docs-first framing artifact and does not retroactively become runtime authority.
+
+## COMMAND PACKET (planning-only)
+
+- **Mode:** `RESEARCH` — source: `docs/governance_mode.md` via branch mapping for `feature/editor-worker-orchestrator`
+- **Category:** `docs`
+- **Risk:** `LOW` — why: this slice adds planning and governance-reference docs only; the main risk is wording drift that could be mistaken for new authority or unnecessary STRICT friction
+- **Required Path:** `Quick`
+- **Lane:** `Concept` — why this is the cheapest admissible lane now: the task is to sequence follow-up work and start the smallest low-friction documentation surfaces before any runtime-adjacent or config-adjacent slice is opened
+- **Objective:** convert the premortem into a phased implementation plan that reduces evidence drift and reproducibility gaps without imposing STRICT-style process on ordinary `RESEARCH` slices
+- **Base SHA:** `66f97acc`
+
+### Scope
+
+- **Scope IN:** one docs-only phase plan; one current-state active-lane index; one claim-bearing evidence header template; one governance README refresh pointing to the new files
+- **Scope OUT:** all edits under `src/**`, `tests/**`, `config/**`, `scripts/**`, `results/**`, and `artifacts/**`; all runnable commands/selectors; all runtime/config-authority/default changes; all paper/live, readiness, promotion, or champion claims; all claims that any later phase is already approved for implementation
+- **Expected changed files:**
+  - `docs/analysis/diagnostics/premortem_followup_phase_plan_2026-05-15.md`
+  - `docs/governance/active_lane_index.md`
+  - `docs/governance/templates/evidence_claim_header.md`
+  - `docs/governance/README.md`
+- **Max files touched:** `4`
+
+### Stop Conditions
+
+- any wording that treats this plan as implementation authority
+- any wording that makes the active-lane index or claim-header template a new SSOT
+- any wording that implies all `RESEARCH` work should now carry STRICT-style packets or gates
+- any widening into `src/**`, `tests/**`, `config/**`, `scripts/**`, `results/**`, or `artifacts/**`
+- any wording that treats future phases as already approved rather than separately admissible questions
+
+## Purpose
+
+This plan answers one narrow question only:
+
+- what is the cheapest phased follow-up that operationalizes the premortem without making routine research work slow?
+
+## Operating principle
+
+The premortem should be implemented as **mis-sized-governance prevention**, not as a universal process tax.
+
+That means:
+
+- high-risk boundaries should become easier to see and harder to cross by accident
+- claim-bearing evidence should become easier to reproduce and harder to overstate
+- ordinary `RESEARCH` slices should remain light unless they actually approach high-sensitivity surfaces
+
+## Phase 1 — Boundary visibility surfaces
+
+Goal:
+
+- reduce evidence-to-authority drift and reproducibility slippage with the smallest docs-only surfaces first
+
+Deliverables:
+
+- `docs/governance/active_lane_index.md`
+- `docs/governance/templates/evidence_claim_header.md`
+- `docs/governance/README.md` refresh so the new surfaces are discoverable
+
+Why this phase comes first:
+
+- it attacks the two highest-leverage premortem risks (`evidence-to-authority drift` and weak claim provenance)
+- it creates almost no runtime or research friction
+- it improves later packets, notes, and evidence summaries without changing behavior
+
+Started in this slice:
+
+- yes
+
+Success criteria:
+
+- a worker can identify the current active lane and parked lanes without rereading the entire working contract
+- a claim-bearing note has a copyable provenance/authority header
+- neither surface claims new authority or adds mandatory gates to ordinary scratch research
+
+## Phase 2 — Runtime-config live-update matrix
+
+Goal:
+
+- make the boundary between schema-valid, propose-allowed, and intentionally blocked runtime fields explicit
+
+Planned output:
+
+- one docs-only matrix or reference note that maps runtime-config fields across:
+  - schema support
+  - propose/update allowance
+  - intended live-updatability stance
+  - explicit blocked surfaces
+
+Current phase-2 reference created in this slice:
+
+- `docs/governance/runtime_config_live_update_matrix_2026-05-15.md`
+
+Current phase-2 clarification surfaces created in this slice:
+
+- `README.md`
+- `config/README.md`
+- `docs/architecture/ARCHITECTURE.md`
+
+Why this is phase 2 instead of phase 1:
+
+- it needs a closer read of `schema.py`, `authority.py`, and API/runtime docs
+- it is still docs-first, but it is nearer a real behavior/ops boundary and should not be rushed into the first kickoff slice
+
+Started in this slice:
+
+- yes
+
+## Phase 3 — Claim-bearing evidence adoption boundary
+
+Goal:
+
+- define how the claim-header template is adopted for actual evidence notes without turning every exploratory note into a heavyweight ritual
+
+Planned output:
+
+- one bounded adoption note or runbook that says when the header is expected and when a lighter scratch note is still acceptable
+- optional clean-checkout replay expectation for artifacts that influence decisions, packets, or candidate promotion arguments
+
+Current phase-3 runbook created in this slice:
+
+- `docs/governance/runbooks/evidence_claim_adoption.md`
+
+Important boundary:
+
+- this phase should stay trigger-based (`claim-bearing`, `decision-influencing`, `promotion-adjacent`) rather than universal for all docs
+
+Started in this slice:
+
+- yes
+
+## Phase 4 — Sensitive hardening candidates
+
+Goal:
+
+- address the premortem items that are real but live near high-sensitivity code and config surfaces
+
+Examples for later separate packets:
+
+- strategy numeric coercion hardening around probabilities / thresholds
+- config-authority alignment where schema support and live proposal surfaces disagree
+- bounded reproducibility automation where claim-bearing evidence depends on a clean-checkout proof
+
+Current phase-4 boundary packets created in this slice:
+
+- `docs/decisions/governance/runtime_config_live_update_policy_boundary_packet_2026-05-15.md`
+- `docs/decisions/governance/decision_gate_finite_numeric_hardening_packet_2026-05-15.md`
+- `docs/decisions/governance/ev_gate_non_finite_expected_value_hardening_packet_2026-05-15.md`
+- `docs/decisions/governance/runtime_config_propose_non_whitelisted_error_semantics_packet_2026-05-15.md`
+- `docs/decisions/governance/execution_proxy_evidence_manifest_closeout_packet_2026-05-15.md`
+
+Important boundary:
+
+- these are **not** phase-1 or phase-2 tasks
+- each one requires its own narrower contract and may need stricter review because it gets closer to runtime, config-authority, or high-sensitivity zones
+- the new boundary packet explicitly says the current docs-only clarification line is sufficient for the present behavior description and that any future source-level whitelist/API change must reopen as a separate bounded pre-code packet
+- the decision-gate packet selects one narrower high-sensitivity candidate for later work: finite-numeric hardening in `src/core/strategy/decision_gates.py`, while explicitly keeping `src/core/strategy/decision.py`, fib-gating, sizing, policy-router, and config-authority surfaces out of scope unless separately reopened
+- the EV-gate packet selects a separate component-level candidate: fail-closed handling for non-finite `expected_value` in `src/core/strategy/components/ev_gate.py`, while explicitly keeping upstream context-builder emission and broader component-pipeline semantics out of scope unless separately reopened
+- the config-authority packet selects the narrowest remaining API-edge alignment candidate: expose a coarse public `non_whitelisted_field` detail for guarded propose rejections, while explicitly keeping whitelist scope and live-write policy unchanged unless separately reopened
+- the reproducibility packet selects the narrowest remaining evidence-closeout candidate: add one deterministic non-self manifest artifact to `execution_proxy_evidence`, while explicitly keeping runtime semantics, shared utility extraction, and broader governance redesign out of scope unless separately reopened
+
+## What changed now
+
+- created a phased follow-up plan anchored to the premortem
+- started the first low-friction governance-reference surfaces in the same slice
+- added a docs-only runtime-config live-update matrix that separates schema support, validate acceptance, and live propose authority
+- added a trigger-based adoption boundary for the evidence claim header so claim-bearing notes become stricter without making scratch research heavy
+- clarified user-facing config docs so `validate` is not misread as live-write authority and the narrower propose whitelist is discoverable from everyday docs
+- added a docs-only boundary packet that stops the current clarification line from bleeding into implicit config-authority implementation work
+- added a second docs-only phase-4 packet that identifies `decision_gates.py` finite-numeric hardening as the next smallest strategy/decision candidate instead of treating phase 4 as an open-ended hardening bucket
+
+## What did not change
+
+- no runtime behavior
+- no config-authority semantics
+- no tests or selectors
+- no paper/live behavior
+- no promotion/champion readiness stance
+- no new SSOT
+
+## Bottom line
+
+The premortem follow-up should begin by making the current lane easier to see and evidence claims easier to frame correctly. That is the smallest step that reduces future rework without punishing ordinary research with unnecessary STRICT-style friction.

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -13,9 +13,10 @@
 - Observability: `GET /observability/dashboard` returnerar counters/gauges/events.
 - Config:
   - `GET /config/runtime` – läser runtime snapshot (`cfg`, `hash`, `version`).
-  - `POST /config/runtime/validate` – validerar en föreslagen runtime-config (returnerar `valid` + felkod).
-  - `POST /config/runtime/propose` – patchar whitelistade fält, skriver atomiskt till `config/runtime.json` och loggar append-only audit till `logs/config_audit.jsonl`.
+  - `POST /config/runtime/validate` – validerar en föreslagen runtime-config mot runtime-schemat (returnerar `valid` + felkod), men `valid=true` innebär inte i sig live-write-authority.
+  - `POST /config/runtime/propose` – patchar whitelistade live-update-fält, kräver bearer + `expected_version`, skriver atomiskt till `config/runtime.json` och loggar append-only audit till `logs/config_audit.jsonl`.
   - Not: JSON Schema v1 helpers finns som funktioner (`core.config.validator.validate_config`, `core.config.validator.diff_config`).
+  - Current-state-matris för schema-valid vs live-skrivbar runtime-config finns i `docs/governance/runtime_config_live_update_matrix_2026-05-15.md`.
 
 ### NonceManager
 

--- a/docs/decisions/governance/decision_gate_finite_numeric_hardening_packet_2026-05-15.md
+++ b/docs/decisions/governance/decision_gate_finite_numeric_hardening_packet_2026-05-15.md
@@ -1,0 +1,143 @@
+# Decision gate finite numeric hardening packet
+
+Date: 2026-05-15
+Branch: `feature/editor-worker-orchestrator`
+Status: `packet-defined / docs-only / non-authorizing`
+
+This document is a planning/decision artifact in `RESEARCH` and grants no implementation, runtime, strategy, config-authority, readiness, paper/live, launch, or promotion authority. It must not be used as approval to begin source, test, config, or API behavior changes.
+
+> Current implementation-status note:
+>
+> - The candidate framed by this packet has since been landed in a separate bounded runtime slice limited to `src/core/strategy/decision_gates.py` and `tests/utils/test_decision.py`.
+> - Verification on that later slice was green on touched-file `black --check` / `ruff check`, focused decision tests, decision/sizing smoke, and determinism/parity/pipeline/feature-cache checks.
+> - Repo-wide `black --check .` remains red on unrelated pre-existing files outside that slice; this note is therefore a targeted-slice verification claim, not a whole-repo formatting-baseline claim.
+> - This packet remains the historical pre-code framing artifact and does not retroactively authorize wider strategy work.
+
+## COMMAND PACKET
+
+- **Mode:** `RESEARCH` — source: `docs/governance_mode.md` via branch mapping for `feature/editor-worker-orchestrator`
+- **Category:** `docs`
+- **Risk:** `LOW` — why: this slice only defines the next bounded pre-code candidate near a high-sensitivity strategy surface; the main risk is wording drift that could be mistaken for approval to perform a broader decision refactor or to alter thresholds/defaults
+- **Required Path:** `Quick`
+- **Lane:** `Concept` — why: this slice selects and bounds the next candidate without entering runtime implementation
+- **Objective:** define the narrowest next pre-code candidate inside strategy/decision surfaces that reduces numeric fragility without changing decision policy, defaults, or gate ordering
+- **Candidate:** `finite-numeric hardening for decision gate parsing`
+- **Base SHA:** `66f97acc`
+
+### Scope
+
+- **Scope IN:** one docs-only packet; explicit description of the observed finite-numeric fragility in `src/core/strategy/decision_gates.py`; explicit relation to the finite/clamp precedent already present in `src/core/strategy/confidence.py`; exact likely future source/test scope for one bounded implementation packet only; explicit done criteria and stop conditions for that future packet
+- **Scope OUT:** all code/test edits in this slice; all changes to thresholds, defaults, tie-break policy, EV formula, HTF/LTF gating, policy-router behavior, sizing behavior, config/schema semantics, paper/live behavior, readiness/promotion claims, or any claim that implementation is already approved
+- **Expected changed files:** `docs/decisions/governance/decision_gate_finite_numeric_hardening_packet_2026-05-15.md`
+- **Max files touched:** `1`
+
+### Gates required
+
+For this packet itself:
+
+- targeted docs validation for this file
+- manual wording audit that this packet remains docs-only and non-authorizing
+- manual wording audit that the candidate stays narrower than a general decision refactor
+- manual wording audit that valid finite-input behavior is described as unchanged unless a later code packet proves otherwise
+
+### Stop Conditions
+
+- any wording that treats this packet as implementation approval
+- any wording that broadens the candidate from numeric hardening into general decision-policy redesign
+- any wording that implies thresholds, defaults, or gate ordering should change as part of this packet
+- any wording that silently absorbs `decision_fib_gating`, `decision_sizing`, `ri_policy_router`, config/schema, or paper/live surfaces into the same future slice
+
+## Purpose
+
+This packet answers one narrow question only:
+
+- what is the next smallest strategy/decision hardening slice worth opening now that the runtime-config documentation ambiguity has already been resolved?
+
+## Governing basis
+
+The current read of the repo suggests a small but real numeric-hardening seam in the decision gate layer:
+
+1. `src/core/strategy/decision_gates.py` defines `safe_float(...)`, which is defensive against `None` and invalid types but currently passes through convertible non-finite numerics such as `NaN` / `±inf`
+2. the same module later performs several `int(...)` conversions from config/state-derived values, including persistence, guard-bar, hysteresis, cooldown, and decision-step paths
+3. those two facts together create a plausible failure mode where strange numeric inputs are no longer just "invalid data" but can become either:
+   - a runtime cast failure, or
+   - a silent gate distortion if a non-finite float reaches comparison logic
+4. `tests/utils/test_decision.py` already covers `None`, numeric strings, and non-numeric strings, but it does not currently anchor `NaN` / `±inf` behavior for these gate-adjacent paths
+5. `src/core/strategy/confidence.py` already contains a local finite/clamp precedent (`_clamp01`, `_clamp`) that treats `NaN`/`±inf` as bounded defensive values rather than trusted numeric inputs
+
+## Why this candidate is narrower than the other phase-4 examples
+
+Compared with other sensitive candidates, this seam is the cheapest next move because it:
+
+- does **not** widen config-authority or live-update policy
+- does **not** require a broad strategy-family or policy-router redesign
+- is likely containable to one gate-parsing module plus focused tests
+- addresses a real failure mechanism without opening paper/live, promotion, or schema-authority questions
+
+## Boundary decision
+
+### Current standing conclusion
+
+The next bounded high-sensitivity candidate should be framed as:
+
+- **finite-numeric hardening for decision gate parsing in `decision_gates.py`**
+
+This is a candidate-selection conclusion only. It is **not** approval to edit the strategy runtime yet.
+
+### Likely future implementation scope
+
+If this candidate is reopened as a real pre-code implementation packet, the smallest honest starting scope is likely:
+
+- `src/core/strategy/decision_gates.py`
+- `tests/utils/test_decision.py`
+
+`src/core/strategy/decision.py` remains **OUT** for the initial slice. If later inspection shows that file must change, the work must stop, amend the packet/contract, and obtain fresh pre-code review before editing it.
+
+### Likely future implementation scope OUT
+
+A future packet for this candidate should keep the following out of scope unless separately reopened:
+
+- `src/core/strategy/decision_fib_gating.py`
+- `src/core/strategy/decision_sizing.py`
+- `src/core/strategy/ri_policy_router.py`
+- confidence scaling semantics beyond reusing an existing finite-handling pattern as precedent
+- config/schema files or runtime live-update surfaces
+- paper/live, promotion, champion, or readiness implications
+
+## What that future pre-code packet must define
+
+A future implementation-bearing packet for this candidate must define at minimum:
+
+- the exact numeric paths being hardened
+- whether the change is limited to `safe_float(...)`, adjacent integer parsing, or both
+- the exact fallback rule for non-finite numeric inputs
+- what must remain unchanged for already-valid finite inputs
+- the smallest focused test additions needed to prove no crash and no silent gate widening
+- what code paths remain explicitly out of scope
+
+## Future done criteria for the implementation slice
+
+If the future implementation slice is opened, it should be considered done only if all of the following are true:
+
+- non-finite numeric inputs in the named decision-gate parsing paths do not raise during gate evaluation
+- non-finite values are handled only through the same invalid/missing-input path already used today; the slice must not create any path more permissive than current `None` / invalid handling
+- those inputs do not widen entry permission relative to the current defensive/default path
+- existing valid finite-input behavior remains unchanged across the targeted decision tests
+- focused tests cover representative `NaN` / `+inf` / `-inf` cases for at least one float path and one int-cast-adjacent path
+- finite-input parity is demonstrated with the existing focused decision tests plus those targeted `NaN` / `+inf` / `-inf` cases only; if broader fixtures, broader selectors, or cross-module edits are required, the slice must stop and reopen as a new packet
+
+## Hard stop and reopen rule
+
+If the future slice needs to change any of the following, it must stop and reopen as a separate bounded packet:
+
+- threshold semantics or default values
+- EV formulas or tie-break policy
+- HTF/LTF fib gating behavior
+- policy-router behavior
+- sizing behavior
+- config/schema authority or live-update semantics
+- broad test rewrites outside the targeted decision-gate subset
+
+## Bottom line
+
+After the runtime-config clarification line, the next smallest risk-reducing move is not broader config policy and not a general strategy refactor. It is a separate bounded pre-code packet for **finite-numeric hardening in `src/core/strategy/decision_gates.py`**, with focused tests and explicit guarantees that valid finite-input behavior stays unchanged.

--- a/docs/decisions/governance/ev_gate_non_finite_expected_value_hardening_packet_2026-05-15.md
+++ b/docs/decisions/governance/ev_gate_non_finite_expected_value_hardening_packet_2026-05-15.md
@@ -1,0 +1,165 @@
+# EV gate non-finite expected-value hardening packet
+
+Date: 2026-05-15
+Branch: `feature/editor-worker-orchestrator`
+Status: `packet-defined / docs-only / non-authorizing`
+
+This document is a planning/decision artifact in `RESEARCH` and grants no implementation, runtime, strategy, config-authority, readiness, paper/live, launch, or promotion authority. It must not be used as approval to begin source, test, config, or API behavior changes.
+
+> Current implementation-status note:
+>
+> - The candidate framed by this packet has since been landed in a separate bounded runtime slice limited to `src/core/strategy/components/ev_gate.py` and `tests/core/strategy/components/test_ev_gate_integration.py`.
+> - Verification on that later slice was green on touched-file `black --check` / `ruff check`, focused EVGate tests, combined EVGate + context-builder component smoke, and the same determinism/parity/pipeline/feature-cache checks used for earlier strategy-adjacent slices.
+> - Executed selectors / outcomes for that later slice:
+>   - `pytest tests/core/strategy/components/test_ev_gate_integration.py -v --tb=short` → `20 passed`
+>   - `black --check src/core/strategy/components/ev_gate.py tests/core/strategy/components/test_ev_gate_integration.py` → `pass`
+>   - `ruff check src/core/strategy/components/ev_gate.py tests/core/strategy/components/test_ev_gate_integration.py` → `pass`
+>   - `pytest tests/core/strategy/components/test_ev_gate_integration.py tests/core/strategy/components/test_context_builder_key_mapping.py -v --tb=short` → `33 passed`
+>   - `pytest tests/backtest/test_backtest_determinism_smoke.py tests/governance/test_regime_intelligence_cutover_parity.py tests/governance/test_pipeline_fast_hash_guard.py tests/integration/test_precompute_vs_runtime.py tests/utils/test_feature_parity.py tests/utils/test_features_asof_cache_isolation.py` → `24 passed`
+> - This packet remains the historical pre-code framing artifact and does not retroactively authorize wider component or pipeline work.
+
+## COMMAND PACKET
+
+- **Mode:** `RESEARCH` — source: `docs/governance_mode.md` via branch mapping for `feature/editor-worker-orchestrator`
+- **Category:** `docs`
+- **Risk:** `LOW` — why: this slice only defines the next bounded pre-code candidate near a runtime strategy component seam; the main risk is wording drift that could be mistaken for approval to widen component semantics or to reopen EV formula/policy questions
+- **Required Path:** `Quick`
+- **Lane:** `Concept` — why: this slice selects and bounds the next candidate without entering runtime implementation
+- **Objective:** define a narrow next pre-code candidate that hardens EV gate handling for non-finite expected values without changing valid finite EV behavior or entry policy semantics
+- **Candidate:** `fail-closed handling for non-finite expected_value in EVGateComponent`
+- **Base SHA:** `66f97acc`
+- **Skill Usage:** no matching repository skill identified for this narrow `ev_gate` hardening slice; no skill coverage claim is made in this packet
+
+### Scope
+
+- **Scope IN:** one docs-only packet; explicit statement of the observed EVGate seam in `src/core/strategy/components/ev_gate.py`; exact likely source/test scope for one bounded future implementation slice only; explicit done criteria and stop conditions for that later slice
+- **Scope OUT:** all code/test edits in this slice; all EV formula changes; all threshold calibration changes; all context-builder semantics changes; all decision/size/router/fib/config/schema changes; all paper/live, readiness, promotion, or shared-truth claims; all claims that implementation is already approved
+- **Expected changed files:** `docs/decisions/governance/ev_gate_non_finite_expected_value_hardening_packet_2026-05-15.md`
+- **Max files touched:** `1`
+
+### Gates required
+
+For this packet itself:
+
+- targeted docs validation for this file
+- manual wording audit that this packet remains docs-only and non-authorizing
+- manual wording audit that the candidate stays narrower than a general EV/component refactor
+- manual wording audit that valid finite-input behavior is described as unchanged unless a later code packet proves otherwise
+
+### Stop Conditions
+
+- any wording that treats this packet as implementation approval
+- any wording that broadens the candidate from non-finite EV hardening into EV formula, threshold, or component-design redesign
+- any wording that silently absorbs `ComponentContextBuilder`, decision pipeline, sizing, router, or config/schema surfaces into the same future slice
+- any wording that implies this packet has already validated runtime correctness without a separate implementation-bearing slice
+
+## Purpose
+
+This packet answers one narrow question only:
+
+- what is the next smallest component-level hardening slice worth opening after the first `decision_gates.py` finite-numeric slice has already landed?
+
+## Governing basis
+
+### Observed
+
+1. `src/core/strategy/components/ev_gate.py` currently treats `expected_value is None` and non-convertible values as defensive vetoes with `EV_MISSING`
+2. the same component currently does `ev_float = float(ev)` and then compares `ev_float < self.min_ev`
+3. for non-finite but convertible values such as `NaN`, `+inf`, and `-inf`, the conversion succeeds
+4. for `NaN` and plausibly `+inf`, the comparison `ev_float < self.min_ev` is not a fail-closed veto, which means the current implementation can plausibly return `allowed=True` for an invalid EV payload
+5. `-inf` already produces a non-allow path through the existing threshold comparison and is therefore not the primary fail-open problem in this seam
+6. current tests in `tests/core/strategy/components/test_ev_gate_integration.py` cover normal allow/veto paths and missing EV, but do not anchor `NaN` / `+inf` / `-inf` behavior
+
+### Inferred
+
+- this seam is narrower than a general component-pipeline redesign because the likely first-touch file is `src/core/strategy/components/ev_gate.py`
+- the likely first proof surface is the EVGate integration test file already present in `tests/core/strategy/components/test_ev_gate_integration.py`
+- the correct hardening target is fail-closed handling for non-finite expected values, not a rewrite of how expected value is computed upstream
+- the narrowest behavior-change exception is likely to be: `NaN` and `+inf` stop following the current fail-open path and instead reuse the existing defensive invalid/missing-input style path, while `-inf` remains on its current non-allow path unless separately reopened
+
+### Unverified in this packet
+
+- whether a later implementation slice can remain fully contained to `ev_gate.py` and one existing test file without any helper extraction
+- whether the preferred fail-closed outcome should reuse `EV_MISSING` exactly or another already-existing defensive reason path, so long as permission does not widen
+
+## Boundary decision
+
+### Current standing conclusion
+
+The next bounded component-level hardening candidate should be framed as:
+
+- **fail-closed handling for non-finite `expected_value` in `src/core/strategy/components/ev_gate.py`**
+
+This is a candidate-selection conclusion only. It is **not** approval to edit the runtime component yet.
+
+### Likely future implementation scope
+
+If this candidate is reopened as a real pre-code implementation packet, the smallest honest starting scope is likely:
+
+- `src/core/strategy/components/ev_gate.py`
+- `tests/core/strategy/components/test_ev_gate_integration.py`
+
+`src/core/strategy/components/context_builder.py` remains **OUT** for the initial slice. If later inspection shows that upstream context emission must change, the work must stop, amend the packet/contract, and obtain fresh pre-code review before editing it.
+
+### Likely future implementation scope OUT
+
+A future packet for this candidate should keep the following out of scope unless separately reopened:
+
+- `src/core/strategy/components/context_builder.py`
+- `src/core/strategy/decision.py`
+- `src/core/strategy/decision_gates.py`
+- `src/core/strategy/decision_sizing.py`
+- `src/core/strategy/ri_policy_router.py`
+- EV formula or calibration semantics
+- config/schema files or runtime live-update surfaces
+- paper/live, promotion, champion, or readiness implications
+
+## What that future pre-code packet must define
+
+A future implementation-bearing packet for this candidate must define at minimum:
+
+- the exact non-finite EV inputs being hardened
+- whether the change is contained to one comparison seam or needs a tiny private helper in `ev_gate.py`
+- the exact fail-closed fallback rule for non-finite values
+- whether `-inf` stays on the current threshold-veto path or is deliberately normalized into the invalid/missing-input path
+- what must remain unchanged for already-valid finite EV inputs
+- the smallest focused tests needed to prove no fail-open behavior and no finite-input drift
+- what code paths remain explicitly out of scope
+
+## Expected verification stack for the implementation slice
+
+If the future implementation slice is opened, the expected minimum verification stack should be:
+
+- touched-file `black --check`
+- touched-file `ruff check`
+- focused `pytest` for `tests/core/strategy/components/test_ev_gate_integration.py`
+- affected-flow component smoke using the EVGate integration test together with `tests/core/strategy/components/test_context_builder_key_mapping.py`
+- determinism/parity check set already used for strategy-adjacent runtime slices
+- feature-cache invariance check set already used for strategy-adjacent runtime slices
+- pipeline invariant / hash-guard checks already used for strategy-adjacent runtime slices
+
+## Future done criteria for the implementation slice
+
+If the future implementation slice is opened, it should be considered done only if all of the following are true:
+
+- `NaN`, `+inf`, and `-inf` expected values do not produce `allowed=True`
+- `NaN` and `+inf` follow the same defensive invalid/missing-input style path already used today and do not widen permission
+- `-inf` either remains on the current non-allow threshold-veto path or is explicitly and separately approved for reason-path normalization before implementation
+- representative valid finite EV inputs remain unchanged across the targeted EVGate tests
+- focused tests cover at least one finite control case plus representative `NaN` / `+inf` / `-inf` cases
+- if implementation requires changing upstream context emission or broader component-pipeline semantics, the slice stops and reopens as a new packet
+
+## Hard stop and reopen rule
+
+If the future slice needs to change any of the following, it must stop and reopen as a separate bounded packet:
+
+- EV formula or threshold semantics
+- `ComponentContextBuilder` emission rules
+- decision-pipeline or sizing behavior
+- router/fib behavior
+- config/schema authority or live-update semantics
+- broad component-framework refactors
+
+## Bottom line
+
+After the first `decision_gates.py` finite-numeric slice, the next smallest risk-reducing move is not a broader component refactor. It is a separate bounded pre-code packet for **fail-closed handling of non-finite `expected_value` in `src/core/strategy/components/ev_gate.py`**, with focused tests and explicit guarantees that valid finite EV behavior stays unchanged.

--- a/docs/decisions/governance/execution_proxy_evidence_manifest_closeout_packet_2026-05-15.md
+++ b/docs/decisions/governance/execution_proxy_evidence_manifest_closeout_packet_2026-05-15.md
@@ -1,0 +1,148 @@
+# Execution proxy evidence manifest closeout packet
+
+Date: 2026-05-15
+Branch: `feature/editor-worker-orchestrator`
+Status: `packet-defined / docs-only / non-authorizing`
+
+This document is a planning/decision artifact in `RESEARCH` and grants no implementation, runtime, config-authority, readiness, paper/live, launch, or promotion authority. It must not be used as approval to begin source, test, or evidence-contract changes without a bounded implementation step.
+
+> Current implementation-status note:
+>
+> - The candidate framed by this packet has since been landed in a separate bounded evidence slice limited to `scripts/analyze/execution_proxy_evidence.py` and `tests/backtest/test_execution_proxy_evidence.py`.
+> - Verification on that later slice was green on touched-file `black --check` / `ruff check` and the focused execution-proxy evidence test file.
+> - Executed selectors / outcomes for that later slice:
+>   - `black --check scripts/analyze/execution_proxy_evidence.py tests/backtest/test_execution_proxy_evidence.py` → `pass`
+>   - `ruff check scripts/analyze/execution_proxy_evidence.py tests/backtest/test_execution_proxy_evidence.py` → `pass`
+>   - `pytest tests/backtest/test_execution_proxy_evidence.py -v --tb=short` → `18 passed`
+> - This packet remains the historical pre-code framing artifact and does not retroactively authorize wider evidence-framework or runtime work.
+
+## COMMAND PACKET
+
+- **Mode:** `RESEARCH` — source: `docs/governance_mode.md` via branch mapping for `feature/editor-worker-orchestrator`
+- **Category:** `tooling`
+- **Risk:** `LOW-MED` — why: this slice would touch an evidence-producing analysis script and its tests, but not runtime strategy, config authority, paper/live execution, or public API edges
+- **Required Path:** `Smallest admissible governed slice`
+- **Lane:** `Research-evidence` — why: the target is a deterministic evidence/closeout surface, not runtime integration
+- **Objective:** select the smallest implementation-bearing reproducibility hardening slice that improves claim-bearing closeout without broad governance/process redesign
+- **Candidate:** `add an explicit deterministic manifest output to execution_proxy_evidence so repeatable outputs also carry stable input/hash/output inventory metadata`
+- **Base SHA:** `66f97acc`
+- **Skill Usage:** consulted the repository evidence-closeout spec `.github/skills/slice_evidence_handoff.json` as a checklist aid for exact gates and closeout evidence; this does not create authority or replace required review/gate judgment
+
+### Scope
+
+- **Scope IN:** one bounded evidence-script slice centered on `scripts/analyze/execution_proxy_evidence.py`; focused test updates in `tests/backtest/test_execution_proxy_evidence.py`; exact output-contract change from three outputs to four outputs with one new deterministic manifest file only
+- **Scope OUT:** all runtime strategy/backtest engine behavior; all API/config-authority behavior; all generic manifest framework extraction; all new CLI flags; all broad repo-wide evidence policy rewrites; all claims that a single script manifest solves global evidence provenance
+- **Expected future changed files:** `scripts/analyze/execution_proxy_evidence.py`, `tests/backtest/test_execution_proxy_evidence.py`
+- **Max files touched:** `2` for implementation, plus packet sync docs if landed
+
+### Gates required
+
+For this packet itself:
+
+- targeted docs validation for this file
+- manual wording audit that the candidate stays on one existing evidence script only
+- manual wording audit that the packet does not imply runtime, promotion, or repo-wide governance authority
+
+### Stop Conditions
+
+- any widening from one evidence script into a repo-wide manifest framework or shared utility extraction
+- any runtime strategy/backtest semantics change
+- any output that becomes self-referential or non-deterministic because the manifest hashes itself
+- any change that requires new CLI flags, environment variables, or output roots beyond the current bounded script contract
+
+## Purpose
+
+This packet answers one narrow question only:
+
+- what is the smallest real reproducibility closeout slice left from the premortem now that claim-bearing docs boundaries already exist?
+
+## Governing basis
+
+### Observed
+
+1. `docs/governance/templates/evidence_claim_header.md` and `docs/governance/runbooks/evidence_claim_adoption.md` already define when claim-bearing notes should record provenance and authority boundaries
+2. `scripts/analyze/execution_proxy_evidence.py` already produces deterministic repeatable outputs and an internal determinism audit, and `tests/backtest/test_execution_proxy_evidence.py` already proves same-input repeatability and repeatable CLI outputs
+3. unlike stronger replay/evidence scripts such as `scripts/analyze/scpe_ri_v1_router_replay.py`, the execution-proxy evidence script does not currently emit a dedicated manifest recording approved output files, stable non-self output hashes, and an input payload hash in one closeout artifact
+4. the current CLI tests therefore prove byte-repeatability, but the output set still lacks one explicit closeout surface that a later claim-bearing note could cite as a compact inventory/hash anchor
+
+### Inferred
+
+- the smallest useful reproducibility hardening is not a new generic evidence framework; it is to upgrade one already-deterministic evidence script with a deterministic manifest output
+- this candidate is smaller and safer than building repo-wide helpers because the script already computes non-self output hashes and determinism audit data
+- the manifest must remain non-self-referential: it should hash the other approved outputs, not itself
+
+### Unverified in this packet
+
+- the exact manifest filename (`manifest.json` vs a script-specific name) to use for best consistency with existing evidence surfaces
+- the final minimum field set beyond input hash, approved output file list, non-self output hashes, and determinism verdict
+
+## Boundary decision
+
+### Current standing conclusion
+
+The smallest remaining reproducibility/evidence hardening candidate should be framed as:
+
+- **add one deterministic manifest output to `execution_proxy_evidence` that records input hash, approved output inventory, and non-self output hashes**
+
+This is a candidate-selection conclusion only. It is **not** approval to edit the script yet.
+
+### Likely future implementation scope
+
+If this candidate is reopened as a real implementation slice, the smallest honest starting scope is:
+
+- `scripts/analyze/execution_proxy_evidence.py`
+- `tests/backtest/test_execution_proxy_evidence.py`
+
+### Likely future implementation scope OUT
+
+A future packet for this candidate should keep the following out of scope unless separately reopened:
+
+- generic shared manifest utilities
+- other analysis scripts
+- runtime/backtest execution semantics
+- new output directories or CLI options
+- broader docs/governance rewrites beyond minimal indexing/status sync
+
+## What that future implementation slice must define
+
+A future implementation-bearing step for this candidate must define at minimum:
+
+- the exact new output filename
+- the exact approved output set after the change
+- the exact non-self hash basis used by the manifest
+- whether the manifest records the canonical input payload hash
+- which existing tests are updated versus which new regression is added
+- what must remain unchanged in the evidence payload and summary content
+
+## Expected verification stack for the implementation slice
+
+If the future implementation slice is opened, the expected minimum verification stack should be:
+
+- touched-file `black --check`
+- touched-file `ruff check`
+- `pytest tests/backtest/test_execution_proxy_evidence.py -v --tb=short`
+- focused assertions that the CLI output set is deterministic across repeated runs and now includes the new manifest file only
+
+## Future done criteria for the implementation slice
+
+If the future implementation slice is opened, it should be considered done only if all of the following are true:
+
+- `execution_proxy_evidence` still produces deterministic repeatable outputs for identical input
+- the approved output set increases by exactly one deterministic manifest file and nothing else
+- the manifest records a stable input hash and stable non-self output hashes
+- the manifest does not hash itself or introduce nondeterminism
+- existing evidence payload/summary semantics remain unchanged
+
+## Hard stop and reopen rule
+
+If the future slice needs to change any of the following, it must stop and reopen as a separate bounded packet:
+
+- runtime/backtest semantics
+- shared utility extraction
+- additional scripts beyond `execution_proxy_evidence`
+- new CLI contract or flag surface
+- broad evidence policy or governance semantics
+
+## Bottom line
+
+The last small premortem reproducibility move should not be a repo-wide framework. It should be a bounded evidence-script hardening step that lets `execution_proxy_evidence` emit one explicit deterministic manifest closeout artifact alongside its already repeatable outputs.

--- a/docs/decisions/governance/runtime_config_live_update_policy_boundary_packet_2026-05-15.md
+++ b/docs/decisions/governance/runtime_config_live_update_policy_boundary_packet_2026-05-15.md
@@ -1,0 +1,163 @@
+# Runtime config live-update policy boundary packet
+
+Date: 2026-05-15
+Branch: `feature/editor-worker-orchestrator`
+Status: `packet-boundary-defined / docs-only / non-authorizing`
+
+This document is a planning/decision artifact in `RESEARCH` and grants no implementation, runtime, config-authority, readiness, paper/live, launch, or promotion authority. It must not be used as approval to begin code, config, test, or API behavior changes.
+
+## COMMAND PACKET
+
+- **Mode:** `RESEARCH` — source: `docs/governance_mode.md` via branch mapping for `feature/editor-worker-orchestrator`
+- **Category:** `docs`
+- **Risk:** `LOW` — why: this slice only defines the boundary for any future runtime-config live-update policy work; the main risk is wording drift that could be mistaken for approval to widen the live-write surface or to treat the current B1 reading as a permanent design lock
+- **Required Path:** `Quick`
+- **Objective:** define what packet type must come next, if work continues, before any runtime-config live-update whitelist or API-semantics change is considered on the current repository surface
+- **Candidate:** `future runtime-config live-update policy clarification / expansion line`
+- **Base SHA:** `66f97acc`
+
+### Scope
+
+- **Scope IN:** one docs-only boundary packet; explicit relation to the current-state live-update matrix, current docs clarifications, and existing audit note; explicit statement of what the current docs-only line already resolved; explicit stop/reopen rules for any future code/config/API change; explicit definition of the next admissible packet type only
+- **Scope OUT:** all edits under `src/**`, `tests/**`, `config/**`, `scripts/**`, `results/**`, and `artifacts/**`; all whitelist expansion; all API behavior changes; all runtime/default changes; all readiness/promotion/paper/live claims; all claims that future implementation is already approved
+- **Expected changed files:** `docs/decisions/governance/runtime_config_live_update_policy_boundary_packet_2026-05-15.md`
+- **Max files touched:** `1`
+
+### Gates required
+
+For this packet itself:
+
+- targeted docs validation for this file
+- manual wording audit that this packet remains docs-only and non-authorizing
+- manual wording audit that current behavior description is kept separate from future policy choice
+- manual wording audit that no source-change authority is implied
+
+### Stop Conditions
+
+- any wording that treats this packet as approval to widen the live-write whitelist
+- any wording that treats current docs clarification as a code-change authorization
+- any wording that makes `validate` success equivalent to live-write authority
+- any wording that treats the current B1 reading as a permanently chosen implementation policy rather than the current observed repo state
+- any wording that mixes future docs-only clarification and source changes into one implicitly approved packet
+
+## Purpose
+
+This packet answers one narrow question only:
+
+- what packet type must come next, if work continues, before any runtime-config live-update behavior or whitelist change can be considered?
+
+## Governing basis
+
+This packet is downstream of the following already visible current-state surfaces:
+
+- `docs/governance/runtime_config_live_update_matrix_2026-05-15.md`
+- `docs/audit/CONFIG_GOVERNANCE_AUDIT.md`
+- `README.md`
+- `config/README.md`
+- `docs/architecture/ARCHITECTURE.md`
+- `src/core/api/config.py`
+- `src/core/config/authority.py`
+- `src/core/config/schema.py`
+
+Carried-forward meaning:
+
+1. the repository currently documents that `validate` is broader than live-write authority
+2. the current guarded live-write surface is the `propose` path backed by `ConfigAuthority.propose_update(...)`
+3. the current observed repo reading is closest to a **B1 safety-model interpretation**: narrower live-write surface, now documented more explicitly
+4. none of the above by itself decides whether a future broader live-update surface should or should not exist
+
+## What the current docs-only line already resolved
+
+The current docs-only follow-up has already made the following materially clearer:
+
+- `validate` should be read as schema/config-object validation, not as live-write approval
+- `propose` is the actual guarded live-write path
+- the live-write surface is intentionally narrower than the declared runtime schema on the current repo surface
+- user-facing docs now point at the current-state matrix instead of implying all schema-valid fields are live-updatable
+
+That means the current line has already resolved the **documentation ambiguity** that motivated the premortem follow-up.
+
+This packet therefore does **not** reopen that ambiguity as if it were still unresolved.
+
+## What is not required next
+
+Because the current docs-only line already clarified the present behavior, the next step does **not** need to be:
+
+- an immediate whitelist-expansion implementation slice
+- a broad config-authority refactor
+- a combined docs-plus-code "small fix" slice
+- a runtime-default change
+- an API behavior change folded into a docs clarification task
+
+Why:
+
+- the current observed behavior is now documented clearly enough to avoid the earlier false implication that schema-valid means live-writable
+- the remaining question is no longer "what does the repo do now?"
+- the remaining question, if work continues, is whether the repo should keep the current guarded live-write surface or deliberately widen it for a small explicit field set
+
+## Boundary decision
+
+### Current standing conclusion
+
+The docs-only follow-up line is sufficient for the current B1-style reading:
+
+- current behavior is documented
+- current live-write scope is clearer
+- no source change is required merely to make the present contract legible
+
+This is a **current-state documentation conclusion**, not a future implementation lock.
+
+### What the next admissible packet may be
+
+If work continues beyond the current docs-only line, the next admissible step may only be:
+
+- a **separate pre-code packet for one exact bounded live-update policy change candidate**
+
+That future packet must choose one explicit objective, such as:
+
+- widening the live-write surface for one small explicit field set, or
+- tightening/reshaping user-facing error semantics for the guarded live-write path
+
+It must **not** combine multiple policy moves by convenience.
+
+### What that future pre-code packet must define
+
+A future bounded packet must define at minimum:
+
+- the exact field set under consideration
+- whether the slice is docs-only or implementation-bearing
+- whether `src/core/config/authority.py`, `src/core/api/config.py`, or `src/core/config/schema.py` must change
+- what tests/gates become necessary if code changes are required
+- what must remain unchanged on the default path
+- what live-write surfaces remain explicitly out of scope
+- what rollback / stop rules apply if the change spreads beyond the named field set
+
+## Hard stop and reopen rule
+
+From this boundary onward, if any future work needs to modify:
+
+- `src/core/config/authority.py`
+- `src/core/api/config.py`
+- `src/core/config/schema.py`
+- tests that define current config API or authority semantics
+- user-facing docs in order to describe newly changed semantics rather than current behavior
+
+then that work must stop and reopen as a **separate bounded packet**.
+
+No future slice may silently absorb a source change under the cover of the already completed docs-only clarification line.
+
+## What remains out of scope now
+
+Still out of scope beyond this packet:
+
+- whitelist expansion
+- config-authority refactor
+- actor-specific write-permission model
+- runtime-default changes
+- schema changes
+- API error-contract changes
+- readiness, promotion, paper/live, or champion implications
+
+## Bottom line
+
+The current docs-only line is sufficient to document the present runtime-config live-update boundary. The next honest question, if work continues, is no longer "what does the repo do now?" but "do we want to change the live-update policy for one exact bounded surface?". If that question is reopened, it must start with a separate pre-code packet rather than by smuggling code or config-authority changes into the already completed docs clarification work.

--- a/docs/decisions/governance/runtime_config_propose_non_whitelisted_error_semantics_packet_2026-05-15.md
+++ b/docs/decisions/governance/runtime_config_propose_non_whitelisted_error_semantics_packet_2026-05-15.md
@@ -1,0 +1,160 @@
+# Runtime config propose non-whitelisted error semantics packet
+
+Date: 2026-05-15
+Branch: `feature/editor-worker-orchestrator`
+Status: `packet-defined / docs-only / non-authorizing`
+
+This document is a planning/decision artifact in `RESEARCH` and grants no implementation, runtime, config-authority, readiness, paper/live, launch, or promotion authority. It must not be used as approval to begin source, test, config, or API behavior changes.
+
+> Current implementation-status note:
+>
+> - The candidate framed by this packet has since been landed in a separate bounded slice limited to `src/core/api/config.py`, `tests/integration/test_config_endpoints.py`, and `tests/integration/test_config_api_e2e.py`.
+> - Verification on that later slice was green on touched-file `black --check` / `ruff check`, focused config endpoint/e2e tests, and the same runtime-adjacent determinism/parity/pipeline/feature-cache checks used for earlier sensitive slices.
+> - Executed selectors / outcomes for that later slice:
+>   - `black --check src/core/api/config.py tests/integration/test_config_endpoints.py tests/integration/test_config_api_e2e.py` → `pass`
+>   - `ruff check src/core/api/config.py tests/integration/test_config_endpoints.py tests/integration/test_config_api_e2e.py` → `pass`
+>   - `pytest tests/integration/test_config_endpoints.py tests/integration/test_config_api_e2e.py -v --tb=short` → `10 passed`
+>   - `pytest tests/backtest/test_backtest_determinism_smoke.py tests/governance/test_regime_intelligence_cutover_parity.py tests/governance/test_pipeline_fast_hash_guard.py tests/integration/test_precompute_vs_runtime.py tests/utils/test_feature_parity.py tests/utils/test_features_asof_cache_isolation.py -v --tb=short` → `24 passed`
+> - This packet remains the historical pre-code framing artifact and does not retroactively authorize wider config-authority or API work.
+
+## COMMAND PACKET
+
+- **Mode:** `RESEARCH` — source: `docs/governance_mode.md` via branch mapping for `feature/editor-worker-orchestrator`
+- **Category:** `security`
+- **Risk:** `LOW-MED` — why: this slice would touch a runtime/config-authority API edge, but only to make one existing guarded failure mode more explicit; the main risk is accidentally widening live-write authority or leaking internal validation details
+- **Required Path:** `Full`
+- **Lane:** `Runtime-integration` — why: even a small user-visible change on `/config/runtime/propose` touches an authority edge and therefore cannot stay concept-only
+- **Objective:** define the narrowest config-authority alignment candidate that clarifies the guarded live-write boundary without changing whitelist scope or runtime mutability policy
+- **Candidate:** `return an explicit public non_whitelisted_field error for schema-valid but live-blocked propose patches`
+- **Base SHA:** `66f97acc`
+- **Skill Usage:** no suitable repository skill found for this narrow config-authority error-semantics slice; no skill coverage claim is made in this packet, and any future skill addition is only `föreslagen`
+
+### Scope
+
+- **Scope IN:** one docs-only packet; explicit statement of the current API seam where `validate` may accept a payload that `propose` rejects, yet `/config/runtime/propose` currently returns a generic `bad_request`; exact likely future source/test scope for one bounded implementation slice only; explicit done criteria and stop conditions for that later slice
+- **Scope OUT:** all whitelist expansion; all new live-writable fields; all config default changes; all schema changes; all auth changes; all leaked internal exception text or raw field paths; all paper/live, readiness, promotion, or shared-truth claims; all claims that implementation is already approved
+- **Expected changed files:** `docs/decisions/governance/runtime_config_propose_non_whitelisted_error_semantics_packet_2026-05-15.md`
+- **Max files touched:** `1`
+
+### Gates required
+
+For this packet itself:
+
+- targeted docs validation for this file
+- manual wording audit that this packet remains docs-only and non-authorizing
+- manual wording audit that the candidate stays narrower than whitelist expansion or broader API redesign
+- manual wording audit that current runtime authority boundaries remain unchanged in the packet language
+
+### Stop Conditions
+
+- any wording that treats this packet as implementation approval
+- any wording that widens the change from public error semantics into whitelist or schema policy changes
+- any wording that leaks internal exception-derived detail, nested field paths, or raw validation messages into the public API contract
+- any wording that silently absorbs `authority.py` whitelist expansion, auth changes, or UI/runtime behavior changes into the same future slice
+
+## Purpose
+
+This packet answers one narrow question only:
+
+- what is the smallest admissible config-authority alignment slice now that the repo already documents the asymmetry between `validate` and `propose`?
+
+## Governing basis
+
+### Observed
+
+1. `src/core/api/config.py` currently maps all `ValueError` failures from `authority.propose_update(...)` to a generic HTTP `400` with detail `bad_request`
+2. `src/core/config/authority.py` already distinguishes internal failure causes such as `non_whitelisted_field`, `non_whitelisted_field:*`, `invalid_value:*`, and `validation_error`
+3. `docs/governance/runtime_config_live_update_matrix_2026-05-15.md` and user-facing docs already make the current asymmetry explicit: some surfaces are schema-valid but intentionally live-blocked
+4. because `/config/runtime/propose` currently collapses those guarded rejections into `bad_request`, a caller can know from docs that the field is live-blocked but still receive an undifferentiated API error
+5. `RuntimeConfig` accepts top-level fields such as `warmup_bars`, but `ConfigAuthority.propose_update(...)` only whitelists top-level keys `{strategy_family, thresholds, gates, risk, ev, multi_timeframe}`; `warmup_bars` is therefore a concrete schema-valid but live-blocked proof seam
+6. a targeted search of `src/**` for exact `bad_request` coupling found only the current `src/core/api/config.py` mapping site and no in-repo caller branching on this specific error detail
+
+### Inferred
+
+- the smallest useful alignment is not whitelist expansion, but a bounded public error code for the existing guarded failure mode
+- the safest public code is likely a stable coarse detail such as `non_whitelisted_field`, without leaking nested internal suffixes or raw exception text
+- this candidate can likely remain contained to `src/core/api/config.py` plus focused integration/API tests
+- the match predicate must stay token-safe: only exact `non_whitelisted_field` or `non_whitelisted_field:`-prefixed authority failures are admissible for remapping in this slice
+
+### Unverified in this packet
+
+- whether the final implementation should map only `non_whitelisted_field*` to a public specific detail, or also normalize other guarded `ValueError` families into additional coarse codes
+- whether a small docs clarification is needed after implementation, depending on how explicit the public error contract becomes
+
+## Boundary decision
+
+### Current standing conclusion
+
+The next bounded config-authority candidate should be framed as:
+
+- **return an explicit public `non_whitelisted_field` error for guarded propose rejections caused by live-blocked fields**
+
+This is a candidate-selection conclusion only. It is **not** approval to edit the runtime config API yet.
+
+### Likely future implementation scope
+
+If this candidate is reopened as a real pre-code implementation packet, the smallest honest starting scope is likely:
+
+- `src/core/api/config.py`
+- `tests/integration/test_config_api_e2e.py`
+- `tests/integration/test_config_endpoints.py`
+
+`src/core/config/authority.py` remains **OUT** for the initial slice unless inspection shows a strictly necessary helper or test seam that cannot be handled from the API layer alone. If that becomes necessary, the work must stop, amend the packet/contract, and obtain fresh pre-code review before editing it.
+
+### Likely future implementation scope OUT
+
+A future packet for this candidate should keep the following out of scope unless separately reopened:
+
+- `src/core/config/authority.py` whitelist contents
+- `src/core/config/schema.py`
+- live-write surface expansion
+- auth/bearer behavior
+- UI error handling
+- paper/live, readiness, promotion, or champion implications
+
+## What that future pre-code packet must define
+
+A future implementation-bearing packet for this candidate must define at minimum:
+
+- the exact `ValueError` family being made public as a coarse stable error detail
+- the exact token-safe predicate: `str(exc) == "non_whitelisted_field"` or `str(exc).startswith("non_whitelisted_field:")`
+- whether only `non_whitelisted_field*` is remapped in this slice
+- the exact public detail string to expose
+- what must remain unchanged for all other propose failure paths
+- that the `ValueError` catch must not be widened beyond the existing `authority.propose_update(...)` call site
+- the smallest focused tests needed to prove no authority widening and no exception-detail leakage
+- what code paths remain explicitly out of scope
+
+## Expected verification stack for the implementation slice
+
+If the future implementation slice is opened, the expected minimum verification stack should be:
+
+- touched-file `black --check`
+- touched-file `ruff check`
+- `pytest tests/integration/test_config_endpoints.py tests/integration/test_config_api_e2e.py -v --tb=short`
+- `pytest tests/backtest/test_backtest_determinism_smoke.py tests/governance/test_regime_intelligence_cutover_parity.py tests/governance/test_pipeline_fast_hash_guard.py tests/integration/test_precompute_vs_runtime.py tests/utils/test_feature_parity.py tests/utils/test_features_asof_cache_isolation.py -v --tb=short`
+
+## Future done criteria for the implementation slice
+
+If the future implementation slice is opened, it should be considered done only if all of the following are true:
+
+- schema-valid but live-blocked propose patches no longer collapse to indistinguishable `bad_request` when the failure cause is `non_whitelisted_field*`
+- the public error detail remains coarse and does not expose nested internal suffixes or raw exception text
+- whitelist scope and runtime mutability policy remain unchanged
+- non-whitelist propose failures retain their previous behavior unless explicitly approved in the packet
+- focused tests prove `validate` success plus guarded `propose` rejection for `warmup_bars`, with the new coarse error detail and no leaked internals
+
+## Hard stop and reopen rule
+
+If the future slice needs to change any of the following, it must stop and reopen as a separate bounded packet:
+
+- whitelist contents or live-writable field set
+- schema support
+- public error detail for additional unrelated error families
+- bearer/auth behavior
+- UI/runtime behavior beyond the coarse API detail
+- config-authority semantics beyond this one guarded failure seam
+
+## Bottom line
+
+The next smallest config-authority alignment move is not whitelist expansion. It is a separate bounded pre-code packet for **making guarded non-whitelisted propose failures explicit at the public API edge**, while keeping whitelist scope, schema support, and runtime mutability policy unchanged.

--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -46,11 +46,25 @@ Operativa dokument i `docs/governance/**` är **kompletterande**, inte överstyr
 
 - `concept_evidence_runtime_lane_model_2026-04-23.md` — kanonisk praktisk definition av koncept-, evidens- och runtime-integrations-lanes
 - `GENESIS_HYBRID_V1_1.md` — operativt kontrakt (hybridmodell)
+- `active_lane_index.md` — kort current-state-index som pekar på aktiv lane, parkerade lanes och förbjudna inheritance-gränser utan att bli ny SSOT
+- `runtime_config_live_update_matrix_2026-05-15.md` — current-state-matris för vilka runtime-config-ytor som är schema-valida, validate-accepterade respektive live-skrivbara via propose-pathen
 - `templates/command_packet.md` — standardmall för start av uppgift
+- `templates/evidence_claim_header.md` — lätt claim-header-mall för claim-bearing evidensnoter där provenance och authority-gränser behöver bli tydliga
+- `runbooks/evidence_claim_adoption.md` — trigger-baserad användningsgräns för när claim-headern behövs och när scratch-noter fortfarande får vara lätta
 - `runbooks/trivial_fast_lane.md` — snabbspår för triviala ändringar
 
 Historiska packet-, signoff- och closeout-dokument som låg direkt i governance-roten har flyttats till `docs/decisions/` eller `docs/analysis/` enligt faktisk dokumentroll.
 Äldre material i andra ytor ska fortfarande läsas med respekt för innehållets faktiska roll, inte enbart efter mappnamnet.
+
+## Närliggande aktuella decision-packets
+
+Aktuella governance-nära packets ligger nu under `docs/decisions/governance/`, till exempel:
+
+- `docs/decisions/governance/runtime_config_live_update_policy_boundary_packet_2026-05-15.md` — docs-only boundary packet som säger att varje framtida live-update-policyändring måste öppnas som en separat bounded pre-code slice
+- `docs/decisions/governance/decision_gate_finite_numeric_hardening_packet_2026-05-15.md` — pre-code packet för smal finite-numeric hardening i `decision_gates.py`; senare följd av en separat bounded runtime-slice
+- `docs/decisions/governance/ev_gate_non_finite_expected_value_hardening_packet_2026-05-15.md` — pre-code packet för smal fail-closed hardening i `EVGateComponent` när `expected_value` är icke-finit; senare följd av en separat bounded runtime-slice
+- `docs/decisions/governance/runtime_config_propose_non_whitelisted_error_semantics_packet_2026-05-15.md` — pre-code packet för smal config-authority/API-alignment som gör live-blockade `propose`-fel tydligare utan att bredda whitelist eller runtime-muterbarhet; senare följd av en separat bounded API-slice
+- `docs/decisions/governance/execution_proxy_evidence_manifest_closeout_packet_2026-05-15.md` — pre-code packet för smal reproducibility-closeout som lägger till ett deterministiskt manifest i `execution_proxy_evidence`; senare följd av en separat bounded evidence-slice
 
 ## Användning (kort)
 

--- a/docs/governance/active_lane_index.md
+++ b/docs/governance/active_lane_index.md
@@ -1,0 +1,101 @@
+# Active lane index
+
+Date: 2026-05-15
+Branch: `feature/editor-worker-orchestrator`
+Status: `current-state reference index / complementary / no new authority`
+
+> Use this page as a short pointer only.
+>
+> - `GENESIS_WORKING_CONTRACT.md` remains the current drift anchor.
+> - The cited packets, synthesis notes, and closeouts remain the actual lane anchors.
+> - This index is meant to reduce reread overhead and evidence-to-authority drift, not to replace the underlying documents.
+
+## What this file does not do
+
+This file does **not**:
+
+- override `docs/governance_mode.md`
+- replace `.github/copilot-instructions.md`, `docs/OPUS_46_GOVERNANCE.md`, `AGENTS.md`, or `GENESIS_WORKING_CONTRACT.md`
+- authorize code/config/test/runtime/paper/promote/champion work
+- turn historical notes into live instructions by convenience
+
+## Current mode
+
+- `RESEARCH` — source: branch mapping for `feature/editor-worker-orchestrator`
+
+## Current active lane
+
+Treat the live repo-wide lane as the bounded **RI policy-router** line summarized in `GENESIS_WORKING_CONTRACT.md`.
+
+Current direction lock and active carrier anchors:
+
+- direction lock: `docs/decisions/regime_intelligence/policy_router/ri_policy_router_payoff_state_translation_precode_packet_2026-04-30.md`
+- bounded runtime carrier anchor: `docs/decisions/regime_intelligence/policy_router/ri_policy_router_continuation_release_hysteresis_runtime_packet_2026-04-30.md`
+
+Current evidence-reading anchors to cite before making claims:
+
+- exact top-line triad synthesis: `docs/analysis/regime_intelligence/policy_router/ri_policy_router_continuation_release_hysteresis_topline_subject_triad_synthesis_2026-05-04.md`
+- D1 bank-state synthesis: `docs/analysis/regime_intelligence/policy_router/ri_policy_router_insufficient_evidence_d1_bank_state_synthesis_2026-05-06.md`
+- mixed-year annual comparison line: `docs/analysis/regime_intelligence/policy_router/ri_policy_router_2023_vs_2017_mixed_year_shape_comparison_2026-05-06.md`
+
+Operational shorthand:
+
+- the current lane is still research/evidence-first
+- some bounded runtime slices already exist historically on this branch context, but new work does **not** inherit runtime/default/promotion authority from them by implication
+- exact-surface findings remain bounded unless a fresh packet explicitly opens a new question
+
+## Parked or closed lanes
+
+Treat the following as non-active unless a fresh task reopens them explicitly:
+
+- earlier `3h` historical validation lane from prior working-anchor state
+- aged-weak second-hit and aged-weak-plus-stability lines (`closed negative / reverted`)
+- July-2024 transport line after late-2024 and `2022-06` falsification (`parked` rather than portable authority)
+- SCPE RI runtime/integration roadmap and seam-inventory docs (`historical future-only`, not active execution guidance)
+
+Key parked/closed references:
+
+- `docs/decisions/regime_intelligence/policy_router/ri_policy_router_aged_weak_active_carrier_truth_parked_handoff_2026-04-27.md`
+- `docs/analysis/regime_intelligence/policy_router/ri_policy_router_insufficient_evidence_translation_parking_synthesis_2026-05-04.md`
+- `docs/analysis/scpe_ri_v1/scpe_ri_v1_runtime_integration_roadmap_2026-04-20.md`
+
+## Not active by default
+
+Unless the user explicitly reopens them with the required authority, do **not** treat these as active:
+
+- inherited runtime/integration authority from RI research docs
+- runtime-default changes
+- paper-shadow follow-up fixes
+- promotion/champion claims from isolated research evidence
+
+## Forbidden inheritance boundaries
+
+Do **not** infer any of the following from the existence of an analysis note, synthesis note, or historical packet alone:
+
+- runtime authority
+- default-path authority
+- promotion or readiness authority
+- champion authority
+- paper/live execution authority
+- Legacy identity from RI-labelled evidence surfaces
+
+Practical reading rule:
+
+- if a note says `observational only`, `historical`, `parked`, `planning-only`, or `non-authoritative`, keep it in that bucket until a later packet explicitly changes the status
+
+## Quick use ritual
+
+1. confirm branch and mode
+2. read `GENESIS_WORKING_CONTRACT.md`
+3. use this page to identify current versus parked anchors
+4. cite the exact anchor docs in any new packet, note, or report
+5. if the intended next step touches high-sensitivity, runtime-default, paper/live, or champion surfaces, stop and open the appropriate stricter path instead of relying on this index
+
+## Update rule
+
+Update this page only when one of these changes:
+
+- active lane anchor
+- parked/non-active lane status
+- explicit forbidden-inheritance boundary wording
+- the smallest pointer set needed to identify the live lane correctly

--- a/docs/governance/runbooks/evidence_claim_adoption.md
+++ b/docs/governance/runbooks/evidence_claim_adoption.md
@@ -1,0 +1,142 @@
+# Evidence claim adoption boundary
+
+Status: `governance runbook / complementary / no new authority`
+
+This runbook explains **when** to use `docs/governance/templates/evidence_claim_header.md` and **when not to**.
+
+It exists to reduce evidence-to-authority drift without turning ordinary `RESEARCH` notes into STRICT-style paperwork.
+
+## What this runbook does not do
+
+This runbook does **not**:
+
+- override `.github/copilot-instructions.md`, `docs/governance_mode.md`, `docs/OPUS_46_GOVERNANCE.md`, or `AGENTS.md`
+- turn the claim header into a new SSOT
+- make every scratch note carry a provenance block
+- grant runtime, promotion, readiness, paper/live, or champion authority
+
+## Core rule
+
+Use the claim header **when the note is likely to carry decision weight outside its immediate scratch context**.
+
+Do **not** use it as a blanket requirement for every exploratory read.
+
+## Use the claim header when any of these are true
+
+- the note claims a result is reproducible
+- the note compares baseline versus candidate behavior
+- the note cites an artifact hash, summary hash, or frozen bundle
+- the note says something is unchanged / identical / divergent in a way that may influence later work
+- the note is likely to be cited in a packet, signoff, review, or promotion discussion
+- the note is likely to influence a runtime-adjacent, config-authority-adjacent, or paper-adjacent decision later
+- the note is being written as a deliberate evidence summary rather than a local scratchpad
+
+## A lighter scratch note is still acceptable when all of these are true
+
+- the work is exploratory or provisional
+- the note is not making a fresh reproducibility claim
+- the note is not anchoring a later packet or decision by itself
+- the note is not citing a new artifact hash as proof
+- the note is clearly readable as a local question, hunch, or first read rather than a locked result
+
+## Practical classification
+
+### 1. Scratch read
+
+Typical shape:
+
+- quick local question
+- rough comparison idea
+- hypothesis list
+- bounded observational jotting
+
+Expected posture:
+
+- no claim header required
+- clearly mark the note as exploratory / provisional if ambiguity is possible
+
+### 2. Claim-bearing evidence note
+
+Typical shape:
+
+- deterministic comparison summary
+- exact-subject evidence summary
+- artifact-backed synthesis note
+- note that says a field/screen/path did or did not survive a check
+
+Expected posture:
+
+- use the claim header
+- separate `observed`, `inferred`, and `unverified`
+- record whether the evidence was rerun in the current slice
+
+### 3. Historical note touched for housekeeping only
+
+Typical shape:
+
+- move, rename, normalization, wording cleanup
+- adding a historical status note
+- taxonomy repair without changing the substantive claim
+
+Expected posture:
+
+- do **not** force a new claim header just because the file was touched
+- preserve historical framing instead of rewriting the note as current execution guidance
+
+### 4. Packet- or review-adjacent evidence note
+
+Typical shape:
+
+- evidence likely to be quoted in a packet, signoff, or review
+- note that narrows the next admissible step
+- note that explains why a runtime-adjacent question is or is not ready
+
+Expected posture:
+
+- use the claim header
+- make the non-authority boundary explicit
+- remember that the header improves provenance but does **not** replace a required packet or review path
+
+## Adoption boundary for existing notes
+
+Do **not** try to retrofit the entire archive.
+
+Prefer this order:
+
+1. new claim-bearing notes
+2. existing notes that are being materially updated with new claims
+3. frequently cited evidence notes that currently lack enough provenance context
+
+Low-priority cases:
+
+- old notes touched only for formatting or relocation
+- historical notes that are clearly non-active and not being reused as live anchors
+- pure scratch notes that are not leaving their local exploratory context
+
+## Minimal use ritual
+
+1. ask: will this note carry decision weight outside the immediate scratch context?
+2. if **no**: keep the note light and clearly exploratory
+3. if **yes**: copy the claim header and fill only the fields that are actually known
+4. if the evidence was not rerun in this slice, say so explicitly
+5. if the subject approaches runtime/default/paper/live/champion surfaces, stop treating the header as enough and open the appropriate governed path
+
+## Common failure modes to avoid
+
+- using a scratch note as if it were a packet-grade evidence anchor
+- backfilling guessed SHAs, hashes, or provenance from memory
+- treating `validate` success as proof of live-write authority
+- adding the header and then blurring `observed` versus `inferred`
+- assuming the header itself grants readiness, promotion, or runtime authority
+
+## Relationship to nearby helper docs
+
+Use together with:
+
+- `docs/governance/templates/evidence_claim_header.md` — the actual copyable header
+- `docs/governance/active_lane_index.md` — short pointer to current versus parked lanes
+- `docs/governance/runtime_config_live_update_matrix_2026-05-15.md` — example of a current-state claim-bearing reference note
+
+## Bottom line
+
+The claim header should be **trigger-based, not universal**. Use it when a note starts becoming evidence that other work may rely on; skip it when the note is still just local exploration. That keeps `RESEARCH` fast while making decision-bearing evidence harder to overstate.

--- a/docs/governance/runtime_config_live_update_matrix_2026-05-15.md
+++ b/docs/governance/runtime_config_live_update_matrix_2026-05-15.md
@@ -1,0 +1,174 @@
+# Runtime config live-update matrix
+
+Date: 2026-05-15
+Branch: `feature/editor-worker-orchestrator`
+Status: `current-state reference / docs-only / no behavior change / no new authority`
+
+> Current status note:
+>
+> - This note documents the **current observed boundary** between `RuntimeConfig`, `/config/runtime/validate`, and `/config/runtime/propose`.
+> - It does **not** change the whitelist, API behavior, or runtime/config-authority semantics.
+> - It should be read as a reference note that reduces confusion around live-updatability, not as approval for expanding the live-write surface.
+
+## Purpose
+
+This note answers one narrow question only:
+
+- which runtime-config surfaces are declared in the runtime schema, which are accepted by validation, and which are currently writable through the live propose path?
+
+## Scope boundary
+
+### In scope
+
+- declared `RuntimeConfig` surfaces in `src/core/config/schema.py`
+- observed `ConfigAuthority.validate(...)` behavior
+- observed `ConfigAuthority.propose_update(...)` whitelist behavior
+- user-facing API semantics in `src/core/api/config.py`
+- current repo reading of which fields are live-writable now
+
+### Out of scope
+
+- changing the whitelist
+- deciding future live-update policy
+- changing API error granularity
+- changing runtime defaults or config-authority behavior
+- treating this matrix as SSOT or implementation authority
+
+## Observed current API behavior
+
+### `GET /config/runtime`
+
+- returns the current canonical snapshot: `{ cfg, version, hash }`
+
+### `POST /config/runtime/validate`
+
+Observed behavior:
+
+- uses `ConfigAuthority.validate(...)`
+- validates the provided payload against `RuntimeConfig`
+- canonicalizes the `regime_unified` compatibility alias into the canonical RI authority path when applicable
+- returns `{ valid, errors, cfg? }`
+- hides internal exception details behind `invalid_config`
+
+Important boundary:
+
+- this endpoint validates the **payload as a config object**, not as a live patch merged onto the current runtime file
+- it does **not** apply the live-update whitelist
+- it therefore cannot be read as "this payload is live-writable"
+
+### `POST /config/runtime/propose`
+
+Observed behavior:
+
+- requires `BEARER_TOKEN`
+- requires `expected_version`
+- expects a `patch` payload
+- runs `ConfigAuthority.propose_update(...)`
+- enforces a path-based whitelist before merge/persist
+- merges the allowed patch onto the current runtime config
+- writes atomically to `config/runtime.json`
+- appends audit entries to `logs/config_audit.jsonl`
+- returns generic `400 bad_request` for `ValueError` cases and `409 version_conflict` for optimistic-lock conflicts
+
+Important boundary:
+
+- this endpoint is the actual live-write surface
+- current live-updatability should be judged from this path, not from schema support alone
+
+## Caveat: declared fields vs permissive extras
+
+`RuntimeSection` uses `extra="allow"`, which means validation can admit additional undeclared keys in some cases.
+
+This matrix intentionally tracks the **declared and repo-cited runtime surfaces** rather than treating permissive extras as an endorsed public contract.
+
+Practical reading rule:
+
+- if a field is not declared in `RuntimeConfig` or explicitly documented by the config API surfaces, do **not** treat validate-time permissiveness as evidence that it is an intended live-update surface
+
+## Top-level matrix
+
+| Surface           | Declared in `RuntimeConfig` | `validate` accepts payload | `propose` accepts live patch | Current repo reading                             | Notes                                                                                                                                                  |
+| ----------------- | --------------------------- | -------------------------- | ---------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `strategy_family` | Yes                         | Yes                        | Yes                          | Live-writable                                    | Values restricted to `legacy` / `ri`; family validation still applies.                                                                                 |
+| `thresholds`      | Yes                         | Yes                        | Yes                          | Live-writable                                    | No extra whitelist narrowing inside `thresholds`; schema/default validation still applies.                                                             |
+| `gates`           | Yes                         | Yes                        | Yes                          | Live-writable                                    | No extra whitelist narrowing inside `gates`; schema/default validation still applies.                                                                  |
+| `risk`            | Yes                         | Yes                        | Partial                      | Live-writable only for `risk_map`                | Any nested key other than `risk_map` is rejected by whitelist.                                                                                         |
+| `ev`              | Yes                         | Yes                        | Partial                      | Live-writable only for `R_default`               | Any nested key other than `R_default` is rejected by whitelist.                                                                                        |
+| `exit`            | Yes                         | Yes                        | No                           | Schema-valid but live-blocked                    | Top-level whitelist rejects `exit`.                                                                                                                    |
+| `multi_timeframe` | Yes                         | Yes                        | Partial                      | Live-writable only for allowlisted nested leaves | See nested matrix below; canonical dump may omit disabled/default-equivalent research leaves.                                                          |
+| `warmup_bars`     | Yes                         | Yes                        | No                           | Schema-valid but live-blocked                    | Top-level whitelist rejects `warmup_bars`.                                                                                                             |
+| `htf_exit_config` | Yes                         | Yes                        | No                           | Schema-valid but live-blocked                    | Top-level whitelist rejects `htf_exit_config`.                                                                                                         |
+| `htf_fib`         | Yes                         | Yes                        | No                           | Schema-valid but live-blocked                    | Top-level whitelist rejects `htf_fib`.                                                                                                                 |
+| `ltf_fib`         | Yes                         | Yes                        | No                           | Schema-valid but live-blocked                    | Top-level whitelist rejects `ltf_fib`.                                                                                                                 |
+| `features`        | Yes                         | Yes                        | No                           | Schema-valid but live-blocked                    | Top-level whitelist rejects `features`.                                                                                                                |
+| `regime_unified`  | Compatibility alias only    | Yes                        | Yes, via canonicalization    | Input-only compatibility bridge                  | Alias is accepted as input, canonicalized into `multi_timeframe.regime_intelligence.authority_mode`, and not persisted as a top-level canonical field. |
+
+## `multi_timeframe` nested live-write matrix
+
+| Path                                                                  | `validate` accepts                           | `propose` accepts         | Current repo reading               | Notes                                                                                                                                                                                                                              |
+| --------------------------------------------------------------------- | -------------------------------------------- | ------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `multi_timeframe.use_htf_block`                                       | Yes                                          | Yes                       | Live-writable                      |                                                                                                                                                                                                                                    |
+| `multi_timeframe.allow_ltf_override`                                  | Yes                                          | Yes                       | Live-writable                      |                                                                                                                                                                                                                                    |
+| `multi_timeframe.ltf_override_threshold`                              | Yes                                          | Yes                       | Live-writable                      |                                                                                                                                                                                                                                    |
+| `multi_timeframe.ltf_override_adaptive.*`                             | Yes                                          | Yes, allowlisted          | Live-writable                      | Allowed keys: `enabled`, `window`, `percentile`, `min_history`, `min_floor`, `max_ceiling`, `fallback_threshold`, `regime_multipliers`.                                                                                            |
+| `multi_timeframe.research_bull_high_persistence_override.*`           | Yes                                          | Yes, allowlisted          | Live-writable                      | Allowed keys: `enabled`, `min_persistence`, `max_probability_gap`, `min_size_base`, `require_non_penalized_volatility_for_min_size_base`.                                                                                          |
+| `multi_timeframe.research_defensive_transition_override.*`            | Yes                                          | Yes, allowlisted          | Live-writable                      | Allowed keys: `enabled`, `guard_bars`, `max_probability_gap`.                                                                                                                                                                      |
+| `multi_timeframe.research_current_atr_high_vol_multiplier_override.*` | Yes                                          | Yes, allowlisted          | Live-writable                      | Allowed keys: `enabled`, `current_atr_threshold`, `high_vol_multiplier_override`.                                                                                                                                                  |
+| `multi_timeframe.research_policy_router.*`                            | Yes                                          | Yes, allowlisted          | Live-writable                      | Allowed keys: `enabled`, `switch_threshold`, `hysteresis`, `continuation_release_hysteresis`, `min_dwell`, `defensive_size_multiplier`. Canonical dump may omit disabled leaves or equal-valued `continuation_release_hysteresis`. |
+| `multi_timeframe.htf_selector.*`                                      | Yes                                          | Yes, allowlisted          | Live-writable                      | Allowed keys: `mode`, `default_timeframe`, `default_multiplier`, `fallback_timeframe`, `per_timeframe`; per-timeframe rules allow `timeframe`, `multiplier`, `label`.                                                              |
+| `multi_timeframe.regime_intelligence.authority_mode`                  | Yes                                          | Yes                       | Live-writable                      | Allowed values: `legacy`, `regime_module`.                                                                                                                                                                                         |
+| `multi_timeframe.regime_intelligence.regime_definition.*`             | Yes                                          | Yes, exact shape required | Live-writable                      | Exact required key set: `adx_trend_threshold`, `adx_range_threshold`, `slope_threshold`, `volatility_threshold`.                                                                                                                   |
+| Any other `multi_timeframe.*` path                                    | Possibly, depending on permissive validation | No                        | Not a supported live-write surface | Do not infer live support from validate-time permissiveness.                                                                                                                                                                       |
+
+## Practical reading
+
+### Observed now
+
+The current repo surface behaves like this:
+
+1. `validate` answers: can this payload instantiate a runtime config object?
+2. `propose` answers: can this patch be live-written through the guarded authority path?
+3. The live-write surface is intentionally narrower than the full declared runtime schema.
+
+### Inferred current policy reading
+
+Based on current code plus `docs/audit/CONFIG_GOVERNANCE_AUDIT.md`, the repository currently behaves closest to:
+
+- **B1 (safety-model reading):** keep a stricter live whitelist and document it clearly
+
+This is an **inference about current behavior**, not a claim that the future policy decision is permanently settled.
+
+## Do not confuse these surfaces
+
+### Runtime config SSOT
+
+- `config/runtime.json`
+- `ConfigAuthority`
+- `RuntimeConfig`
+- `/config/runtime*` API endpoints
+
+### Legacy helper surface
+
+- `core.config.validator.validate_config`
+- `core.config.validator.diff_config`
+- `schema_v1.json`
+
+These legacy helpers are explicitly described as test-only / legacy helpers and must not be mistaken for the current runtime live-update contract.
+
+## What changed in this slice
+
+- created a docs-only reference note that maps schema support, validate acceptance, and propose/live-write allowance
+- made the current whitelist boundary easier to cite in later packets, notes, and reviews
+
+## What did not change
+
+- no code
+- no whitelist expansion
+- no API behavior change
+- no runtime/config-authority semantic change
+- no new live-update permission
+- no new SSOT
+
+## Bottom line
+
+The current Genesis-Core runtime-config surface is deliberately asymmetric: **schema-valid** is broader than **live-writable**. The safe reading for current work is therefore: use `validate` to test config shape, use `propose` to judge live authority, and do not treat successful validation as evidence that a field is intended to be mutable at runtime.

--- a/docs/governance/templates/evidence_claim_header.md
+++ b/docs/governance/templates/evidence_claim_header.md
@@ -1,0 +1,106 @@
+# Evidence claim header template
+
+Status: `complementary template / governance helper / no authority`
+
+Use this template for **claim-bearing evidence notes** — that is, notes or summaries that make reproducibility, comparison, provenance, or boundary claims likely to influence a later packet, decision, or review.
+
+This template is **not** meant to turn every scratch note into a heavyweight ritual.
+
+## Use this template when
+
+- the note claims a result is reproducible
+- the note compares baseline versus candidate behavior
+- the note cites an artifact hash or frozen bundle
+- the note may later be referenced in a packet, signoff, promotion argument, or runtime-adjacent discussion
+
+## A lighter note is still okay when
+
+- the work is exploratory and clearly marked as such
+- no new artifact or reproducibility claim is being made
+- the note is just a question, hunch, or local scratch read
+
+## Minimum fields for a claim-bearing note
+
+At minimum, capture:
+
+- authority level
+- claim status (`observed`, `inferred`, `unverified`)
+- runtime base SHA
+- evidence commit SHA, or an explicit note that the current slice did not rerun the evidence
+- config path and hash when relevant
+- symbol/timeframe/window/warmup when relevant
+- data-source policy
+- symbol mode
+- relevant env flags
+- cache policy
+- working-tree clean/dirty status
+- artifact path(s) and hash(es) when generated or cited
+- a short `does not authorize` boundary
+
+## Copyable header
+
+```md
+## Claim header
+
+- **Date:**
+- **Branch:**
+- **Mode:** `STRICT | RESEARCH | SANDBOX` — source:
+- **Lane:** `Concept | Research-evidence | Runtime-integration` — why:
+- **Status:** `observational / evidence summary / comparison / planning-only`
+- **Authority level:** `observational only / bounded research-evidence / historical reference / other`
+- **Claim status:** `observed / inferred / unverified`
+- **Objective:**
+- **Baseline reference(s):**
+- **Candidate / comparison surface:**
+- **Runtime base SHA:**
+- **Evidence commit SHA:**
+- **Working-tree status:** `clean / dirty / not checked in this slice`
+- **Config path:**
+- **Config hash:**
+- **Symbol / timeframe:**
+- **Window:**
+- **Warmup:**
+- **Data-source policy:**
+- **Symbol mode:**
+- **Env flags:**
+- **Cache policy:**
+- **Artifact path(s):**
+- **Artifact hash(es):**
+- **What changed:**
+- **What did not change:**
+- **Does not authorize:**
+```
+
+## Guidance
+
+### 1. Do not guess missing provenance
+
+If the current slice did **not** rerun the evidence, say so explicitly instead of backfilling guessed values.
+
+Good:
+
+- `Evidence commit SHA: not rerun in this slice; citing frozen artifact from <path>`
+
+Bad:
+
+- silently copying a SHA from memory without checking the cited artifact surface
+
+### 2. Separate observed, inferred, and unverified
+
+A clean header loses value if the body blurs what was actually observed versus what is a later interpretation.
+
+### 3. Dirty worktrees need explicit wording
+
+If the worktree is dirty, record that fact. If the artifact bytes still match `HEAD`, say that explicitly instead of treating all dirty states as the same problem.
+
+### 4. Keep the non-authority boundary short and explicit
+
+Examples:
+
+- `Does not authorize runtime/default changes.`
+- `Does not imply promotion or champion readiness.`
+- `Historical reference only; not active execution guidance.`
+
+## Intent
+
+This template exists to reduce evidence-to-authority drift and weak provenance claims while keeping ordinary `RESEARCH` slices light. It is a helper surface, not a new SSOT or a new mandatory gate stack.

--- a/scripts/analyze/execution_proxy_evidence.py
+++ b/scripts/analyze/execution_proxy_evidence.py
@@ -23,6 +23,9 @@ OUTPUT_FILES = (
     "execution_proxy_evidence.json",
     "execution_proxy_summary.md",
 )
+DETERMINISM_AUDIT_FILE = "audit_execution_proxy_determinism.json"
+MANIFEST_FILE = "manifest.json"
+NON_SELF_OUTPUT_FILES = OUTPUT_FILES + (DETERMINISM_AUDIT_FILE,)
 
 
 class ExecutionProxyEvidenceError(RuntimeError):
@@ -232,7 +235,7 @@ def _trade_sort_key(trade: TradeSignature) -> tuple[Any, ...]:
 
 
 def join_baseline_trades(
-    payload: dict[str, Any]
+    payload: dict[str, Any],
 ) -> tuple[list[JoinedTrade], dict[str, Any], list[dict[str, Any]]]:
     payload_name = payload.get("name")
     if payload_name is not None and payload_name != "baseline_current":
@@ -543,6 +546,40 @@ def _build_manifest_hash(output_hashes: dict[str, str]) -> str:
     return _sha256_text(_canonical_json(output_hashes))
 
 
+def _build_manifest_output(
+    baseline_payload: dict[str, Any],
+    *,
+    horizons: tuple[int, ...],
+    outputs: dict[str, Any],
+    determinism_match: bool,
+) -> dict[str, Any]:
+    missing_outputs = [name for name in NON_SELF_OUTPUT_FILES if name not in outputs]
+    if missing_outputs:
+        raise ExecutionProxyEvidenceError(
+            f"missing approved output(s) for manifest: {', '.join(missing_outputs)}"
+        )
+
+    unexpected_outputs = [name for name in outputs if name not in NON_SELF_OUTPUT_FILES]
+    if unexpected_outputs:
+        raise ExecutionProxyEvidenceError(
+            "unexpected non-self output(s) for manifest: " + ", ".join(sorted(unexpected_outputs))
+        )
+
+    non_self_outputs = {name: outputs[name] for name in NON_SELF_OUTPUT_FILES}
+    output_hashes = _build_non_self_hashes(non_self_outputs)
+
+    return {
+        "input_payload_sha256": _sha256_text(_canonical_json(baseline_payload)),
+        "horizons": [int(value) for value in horizons],
+        "manifest_file": MANIFEST_FILE,
+        "approved_output_files": sorted(NON_SELF_OUTPUT_FILES),
+        "output_hashes": output_hashes,
+        "output_manifest_hash": _build_manifest_hash(output_hashes),
+        "determinism_match": bool(determinism_match),
+        "observational_only": True,
+    }
+
+
 def build_execution_proxy_outputs(
     baseline_payload: dict[str, Any],
     *,
@@ -773,7 +810,7 @@ def run_execution_proxy_evidence(
     run2_hash = _build_manifest_hash(run2_hashes)
 
     outputs = dict(run1)
-    outputs["audit_execution_proxy_determinism.json"] = {
+    outputs[DETERMINISM_AUDIT_FILE] = {
         "non_self_outputs": sorted(run1_hashes),
         "run1_hashes": run1_hashes,
         "run2_hashes": run2_hashes,
@@ -781,6 +818,12 @@ def run_execution_proxy_evidence(
         "run2_hash": run2_hash,
         "match": bool(run1_hashes == run2_hashes and run1_hash == run2_hash),
     }
+    outputs[MANIFEST_FILE] = _build_manifest_output(
+        baseline_payload,
+        horizons=horizons,
+        outputs=outputs,
+        determinism_match=outputs[DETERMINISM_AUDIT_FILE]["match"],
+    )
     return outputs
 
 
@@ -823,7 +866,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.out_dir is not None:
         written = write_outputs(outputs, args.out_dir)
 
-    audit = outputs["audit_execution_proxy_determinism.json"]
+    audit = outputs[DETERMINISM_AUDIT_FILE]
     payload = {
         "status": "PASS" if audit["match"] else "FAIL",
         "horizons": [int(value) for value in args.horizons],

--- a/src/core/api/config.py
+++ b/src/core/api/config.py
@@ -53,7 +53,11 @@ def propose_runtime(payload: dict, authorization: str | None = Header(default=No
             "version": snap.version,
         }
     except ValueError as e:
-        # Avoid leaking exception-derived details; callers should treat 400 uniformly.
+        message = str(e)
+        if message == "non_whitelisted_field" or message.startswith("non_whitelisted_field:"):
+            # Expose only one coarse stable detail for guarded live-write rejections.
+            raise HTTPException(status_code=400, detail="non_whitelisted_field") from e
+        # Avoid leaking exception-derived details for all other 400 failure paths.
         raise HTTPException(status_code=400, detail="bad_request") from e
     except RuntimeError as e:
         if "version_conflict" in str(e):

--- a/src/core/strategy/components/ev_gate.py
+++ b/src/core/strategy/components/ev_gate.py
@@ -93,7 +93,7 @@ class EVGateComponent(StrategyComponent):
                 },
             )
 
-        if math.isnan(ev_float) or ev_float == float("inf"):
+        if math.isnan(ev_float) or (math.isinf(ev_float) and ev_float > 0):
             return ComponentResult(
                 allowed=False,
                 reason="EV_MISSING",

--- a/src/core/strategy/components/ev_gate.py
+++ b/src/core/strategy/components/ev_gate.py
@@ -5,6 +5,7 @@ Allows entry only if expected value meets or exceeds threshold.
 Phase 2 Component: Stateless, entry-only, binary veto.
 """
 
+import math
 from typing import Any
 
 from core.strategy.components.base import ComponentResult, StrategyComponent
@@ -89,6 +90,18 @@ class EVGateComponent(StrategyComponent):
                     "min_ev": self.min_ev,
                     "ev_value": None,
                     "ev_raw": str(ev),
+                },
+            )
+
+        if math.isnan(ev_float) or ev_float == float("inf"):
+            return ComponentResult(
+                allowed=False,
+                reason="EV_MISSING",
+                confidence=0.0,
+                metadata={
+                    "component": self.name(),
+                    "min_ev": self.min_ev,
+                    "ev_value": None,
                 },
             )
 

--- a/src/core/strategy/decision_gates.py
+++ b/src/core/strategy/decision_gates.py
@@ -18,9 +18,30 @@ def safe_float(value: Any, default: float = 0.0) -> float:
     if value is None:
         return default
     try:
-        return float(value)
+        numeric = float(value)
     except (TypeError, ValueError):
         return default
+    if not math.isfinite(numeric):
+        return default
+    return numeric
+
+
+def _is_non_finite_numeric(value: Any) -> bool:
+    if value is None:
+        return False
+    try:
+        return not math.isfinite(float(value))
+    except (TypeError, ValueError, OverflowError):
+        return False
+
+
+def _int_or_default_for_non_finite(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        if _is_non_finite_numeric(value):
+            return int(default)
+        raise
 
 
 def compute_percentile(values: list[float], q: float) -> float:
@@ -238,7 +259,7 @@ def select_candidate(
     zone_debug: dict[str, Any] = {}
     if adaptation_cfg and atr_percentiles:
         zones = adaptation_cfg.get("zones", {})
-        atr_period = int(adaptation_cfg.get("atr_period", 14))
+        atr_period = _int_or_default_for_non_finite(adaptation_cfg.get("atr_period", 14), 14)
         if atr is not None:
             atr_p = atr_percentiles.get(str(atr_period)) or atr_percentiles.get(atr_period) or {}
             atr_safe = safe_float(atr, 0.0)
@@ -542,9 +563,12 @@ def apply_post_fib_gates(
                 action, meta = _none_result(versions, reasons, state_out)
                 return action, meta, {}
 
-    hysteresis_steps = int((cfg.get("gates") or {}).get("hysteresis_steps") or 2)
+    hysteresis_steps = _int_or_default_for_non_finite(
+        (cfg.get("gates") or {}).get("hysteresis_steps") or 2,
+        2,
+    )
     last_action = state_in.get("last_action")
-    decision_steps = int(state_in.get("decision_steps", 0))
+    decision_steps = _int_or_default_for_non_finite(state_in.get("decision_steps", 0), 0)
     if last_action in ("LONG", "SHORT") and candidate != last_action:
         decision_steps += 1
         if decision_steps < hysteresis_steps:
@@ -563,7 +587,7 @@ def apply_post_fib_gates(
         decision_steps = 0
     state_out["decision_steps"] = decision_steps
 
-    cooldown_left = int(state_in.get("cooldown_remaining", 0))
+    cooldown_left = _int_or_default_for_non_finite(state_in.get("cooldown_remaining", 0), 0)
     if cooldown_left > 0:
         reasons.append("COOLDOWN_ACTIVE")
         log_decision_event("COOLDOWN_ACTIVE", remaining=cooldown_left)

--- a/src/core/strategy/decision_gates.py
+++ b/src/core/strategy/decision_gates.py
@@ -19,29 +19,25 @@ def safe_float(value: Any, default: float = 0.0) -> float:
         return default
     try:
         numeric = float(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return default
     if not math.isfinite(numeric):
         return default
     return numeric
 
 
-def _is_non_finite_numeric(value: Any) -> bool:
-    if value is None:
-        return False
-    try:
-        return not math.isfinite(float(value))
-    except (TypeError, ValueError, OverflowError):
-        return False
-
-
 def _int_or_default_for_non_finite(value: Any, default: int) -> int:
+    """Return int(value), defaulting only for non-finite numeric inputs."""
     try:
         return int(value)
-    except (TypeError, ValueError, OverflowError):
-        if _is_non_finite_numeric(value):
+    except (TypeError, ValueError, OverflowError) as exc:
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError, OverflowError):
+            raise exc from None
+        if not math.isfinite(numeric):
             return int(default)
-        raise
+        raise exc from None
 
 
 def compute_percentile(values: list[float], q: float) -> float:

--- a/tests/backtest/test_execution_proxy_evidence.py
+++ b/tests/backtest/test_execution_proxy_evidence.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -106,6 +107,7 @@ def test_run_execution_proxy_evidence_outputs_proxy_surfaces() -> None:
         [
             "audit_execution_proxy_determinism.json",
             "execution_proxy_evidence.json",
+            "manifest.json",
             "execution_proxy_summary.md",
         ]
     )
@@ -197,9 +199,52 @@ def test_run_execution_proxy_evidence_outputs_proxy_surfaces() -> None:
     ]
 
     audit = outputs["audit_execution_proxy_determinism.json"]
+    manifest = outputs["manifest.json"]
     assert audit["match"] is True
+    assert manifest["manifest_file"] == "manifest.json"
+    assert manifest["approved_output_files"] == [
+        "audit_execution_proxy_determinism.json",
+        "execution_proxy_evidence.json",
+        "execution_proxy_summary.md",
+    ]
+    assert manifest["determinism_match"] is True
+    assert manifest["observational_only"] is True
     assert "does not attest realized execution price" in outputs["execution_proxy_summary.md"]
     assert "proxy price-path coverage and missingness only" in outputs["execution_proxy_summary.md"]
+
+
+def test_run_execution_proxy_evidence_manifest_is_non_self_and_repeatable() -> None:
+    payload = _build_payload()
+
+    run1 = run_execution_proxy_evidence(payload, horizons=(1, 2))
+    run2 = run_execution_proxy_evidence(payload, horizons=(1, 2))
+
+    manifest1 = run1["manifest.json"]
+    manifest2 = run2["manifest.json"]
+    expected_input_hash = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
+            "utf-8"
+        )
+    ).hexdigest()
+    expected_output_manifest_hash = hashlib.sha256(
+        json.dumps(
+            manifest1["output_hashes"],
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+    ).hexdigest()
+
+    assert manifest1 == manifest2
+    assert manifest1["input_payload_sha256"] == expected_input_hash
+    assert manifest1["horizons"] == [1, 2]
+    assert manifest1["manifest_file"] == "manifest.json"
+    assert "manifest.json" not in manifest1["approved_output_files"]
+    assert "manifest.json" not in manifest1["output_hashes"]
+    assert set(manifest1["output_hashes"]) == set(manifest1["approved_output_files"])
+    assert manifest1["output_manifest_hash"] == expected_output_manifest_hash
+    assert manifest1["determinism_match"] is True
+    assert manifest1["observational_only"] is True
 
 
 def test_run_execution_proxy_evidence_classifies_interior_proxy_missingness() -> None:
@@ -493,6 +538,7 @@ def test_execution_proxy_evidence_cli_smoke(tmp_path: Path, capsys) -> None:
         "execution_proxy_evidence.json",
         "execution_proxy_summary.md",
         "audit_execution_proxy_determinism.json",
+        "manifest.json",
     }
     assert expected_files == {path.name for path in out_dir.iterdir()}
 
@@ -517,6 +563,7 @@ def test_execution_proxy_evidence_cli_repeatable_outputs(tmp_path: Path, capsys)
         "execution_proxy_evidence.json",
         "execution_proxy_summary.md",
         "audit_execution_proxy_determinism.json",
+        "manifest.json",
     }
     assert expected_files == {path.name for path in out_dir_1.iterdir()}
     assert expected_files == {path.name for path in out_dir_2.iterdir()}

--- a/tests/core/strategy/components/test_ev_gate_integration.py
+++ b/tests/core/strategy/components/test_ev_gate_integration.py
@@ -172,7 +172,7 @@ class TestEVGateNonFiniteHardening:
             pytest.param("inf", id="pos-inf-string"),
         ],
     )
-    def test_ev_gate_non_finite_fail_open_cases_map_to_ev_missing(self, raw_ev) -> None:
+    def test_ev_gate_non_finite_inputs_fail_closed_to_ev_missing(self, raw_ev) -> None:
         ev_gate = EVGateComponent(min_ev=0.1)
 
         ev_result = ev_gate.evaluate({"expected_value": raw_ev})

--- a/tests/core/strategy/components/test_ev_gate_integration.py
+++ b/tests/core/strategy/components/test_ev_gate_integration.py
@@ -131,3 +131,78 @@ class TestEVGateCalibration:
             f"{'allow' if should_allow else 'veto'} "
             f"buy={buy_proba}, sell={sell_proba}"
         )
+
+
+class TestEVGateFiniteBoundaryParity:
+    """Test that valid finite EV behavior remains unchanged around the threshold."""
+
+    @pytest.mark.parametrize(
+        "raw_ev,min_ev,expected_allowed,expected_reason",
+        [
+            pytest.param(0.09, 0.10, False, "EV_BELOW_THRESHOLD", id="below-threshold"),
+            pytest.param(0.10, 0.10, True, None, id="at-threshold"),
+            pytest.param(0.11, 0.10, True, None, id="above-threshold"),
+            pytest.param("0.10", 0.10, True, None, id="string-at-threshold"),
+        ],
+    )
+    def test_ev_gate_preserves_finite_boundary_behavior(
+        self,
+        raw_ev: float | str,
+        min_ev: float,
+        expected_allowed: bool,
+        expected_reason: str | None,
+    ) -> None:
+        ev_gate = EVGateComponent(min_ev=min_ev)
+
+        ev_result = ev_gate.evaluate({"expected_value": raw_ev})
+
+        assert ev_result.allowed is expected_allowed
+        assert ev_result.reason == expected_reason
+
+
+class TestEVGateNonFiniteHardening:
+    """Test fail-closed handling for non-finite EV inputs."""
+
+    @pytest.mark.parametrize(
+        "raw_ev",
+        [
+            pytest.param(float("nan"), id="nan-float"),
+            pytest.param("nan", id="nan-string"),
+            pytest.param(float("inf"), id="pos-inf-float"),
+            pytest.param("inf", id="pos-inf-string"),
+        ],
+    )
+    def test_ev_gate_non_finite_fail_open_cases_map_to_ev_missing(self, raw_ev) -> None:
+        ev_gate = EVGateComponent(min_ev=0.1)
+
+        ev_result = ev_gate.evaluate({"expected_value": raw_ev})
+
+        assert ev_result.allowed is False
+        assert ev_result.reason == "EV_MISSING"
+        assert ev_result.confidence == pytest.approx(0.0)
+        assert ev_result.metadata == {
+            "component": ev_gate.name(),
+            "min_ev": 0.1,
+            "ev_value": None,
+        }
+
+    @pytest.mark.parametrize(
+        "raw_ev",
+        [
+            pytest.param(float("-inf"), id="neg-inf-float"),
+            pytest.param("-inf", id="neg-inf-string"),
+        ],
+    )
+    def test_ev_gate_negative_infinity_preserves_threshold_veto_path(self, raw_ev) -> None:
+        ev_gate = EVGateComponent(min_ev=0.1)
+
+        ev_result = ev_gate.evaluate({"expected_value": raw_ev})
+
+        assert ev_result.allowed is False
+        assert ev_result.reason == "EV_BELOW_THRESHOLD"
+        assert ev_result.confidence == pytest.approx(0.0)
+        assert ev_result.metadata == {
+            "component": ev_gate.name(),
+            "min_ev": 0.1,
+            "ev_value": float("-inf"),
+        }

--- a/tests/integration/test_config_api_e2e.py
+++ b/tests/integration/test_config_api_e2e.py
@@ -166,3 +166,73 @@ def test_runtime_endpoints_e2e_regime_unified_alias_bridge(monkeypatch):
         == "legacy"
     )
     assert out2.get("cfg", {}).get("strategy_family") == "legacy"
+
+
+def test_runtime_endpoints_e2e_schema_valid_live_blocked_field_returns_coarse_detail(
+    monkeypatch,
+):
+    c = TestClient(app)
+
+    validate_payload = {
+        "strategy_family": "legacy",
+        "warmup_bars": 12,
+    }
+    r = c.post(
+        "/config/runtime/validate",
+        json=validate_payload,
+    )
+    assert r.status_code == 200
+    assert r.json().get("valid") is True
+    assert r.json().get("cfg", {}).get("warmup_bars") == 12
+
+    r = c.get("/config/runtime")
+    assert r.status_code == 200
+    v0 = int(r.json().get("version") or 0)
+
+    monkeypatch.setenv("BEARER_TOKEN", "test-secret")
+    r = c.post(
+        "/config/runtime/propose",
+        headers={"Authorization": "Bearer test-secret"},
+        json={
+            "patch": {"warmup_bars": 12},
+            "actor": "test",
+            "expected_version": v0,
+        },
+    )
+
+    assert r.status_code == 400
+    assert r.json() == {"detail": "non_whitelisted_field"}
+    assert "warmup_bars" not in r.text
+
+
+def test_runtime_endpoints_e2e_version_conflict_detail_preserved(monkeypatch):
+    c = TestClient(app)
+
+    r = c.get("/config/runtime")
+    assert r.status_code == 200
+    v0 = int(r.json().get("version") or 0)
+
+    monkeypatch.setenv("BEARER_TOKEN", "test-secret")
+    first_patch = _legacy_runtime_patch(entry_conf_overall=0.63)
+    first = c.post(
+        "/config/runtime/propose",
+        headers={"Authorization": "Bearer test-secret"},
+        json={
+            "patch": first_patch,
+            "actor": "test",
+            "expected_version": v0,
+        },
+    )
+    assert first.status_code == 200
+
+    second = c.post(
+        "/config/runtime/propose",
+        headers={"Authorization": "Bearer test-secret"},
+        json={
+            "patch": _legacy_runtime_patch(entry_conf_overall=0.64),
+            "actor": "test",
+            "expected_version": v0,
+        },
+    )
+    assert second.status_code == 409
+    assert second.json() == {"detail": "version_conflict"}

--- a/tests/integration/test_config_endpoints.py
+++ b/tests/integration/test_config_endpoints.py
@@ -209,3 +209,58 @@ def test_runtime_endpoints_do_not_leak_exceptions(monkeypatch):
     )
     assert r.status_code == 500
     assert "SECRET_SHOULD_NOT_LEAK" not in r.text
+
+
+def test_runtime_propose_nested_non_whitelisted_detail_is_coarse(monkeypatch):
+    c = TestClient(app)
+
+    r = c.get("/config/runtime")
+    assert r.status_code == 200
+    v0 = int(r.json().get("version") or 0)
+
+    monkeypatch.setenv("BEARER_TOKEN", "test-secret")
+    r = c.post(
+        "/config/runtime/propose",
+        headers={"Authorization": "Bearer test-secret"},
+        json={
+            "patch": {
+                "multi_timeframe": {
+                    "regime_intelligence": {
+                        "regime_definition": {
+                            "adx_trend_threshold": 25.0,
+                        }
+                    }
+                }
+            },
+            "actor": "test",
+            "expected_version": v0,
+        },
+    )
+
+    assert r.status_code == 400
+    assert r.json() == {"detail": "non_whitelisted_field"}
+    assert "regime_definition" not in r.text
+    assert "adx_trend_threshold" not in r.text
+    assert ":" not in r.json()["detail"]
+
+
+def test_runtime_propose_invalid_value_stays_bad_request(monkeypatch):
+    c = TestClient(app)
+
+    r = c.get("/config/runtime")
+    assert r.status_code == 200
+    v0 = int(r.json().get("version") or 0)
+
+    monkeypatch.setenv("BEARER_TOKEN", "test-secret")
+    r = c.post(
+        "/config/runtime/propose",
+        headers={"Authorization": "Bearer test-secret"},
+        json={
+            "patch": {"strategy_family": "not-a-valid-family"},
+            "actor": "test",
+            "expected_version": v0,
+        },
+    )
+
+    assert r.status_code == 400
+    assert r.json() == {"detail": "bad_request"}

--- a/tests/utils/test_decision.py
+++ b/tests/utils/test_decision.py
@@ -252,6 +252,195 @@ def test_decide_handles_non_numeric_confidence_without_typeerror() -> None:
     assert "CONF_TOO_LOW" in (meta.get("reasons") or [])
 
 
+def test_decide_preserves_finite_hysteresis_string_behavior() -> None:
+    cfg_int = {
+        "thresholds": {"entry_conf_overall": 0.7, "regime_proba": {"balanced": 0.7}},
+        "risk": {"risk_map": [[0.7, 0.01]]},
+        "gates": {"cooldown_bars": 0, "hysteresis_steps": 1},
+    }
+    cfg_str = deepcopy(cfg_int)
+    cfg_str["gates"]["hysteresis_steps"] = "1"
+
+    kwargs = {
+        "policy": {},
+        "probas": {"buy": 0.8, "sell": 0.1},
+        "confidence": {"buy": 0.8, "sell": 0.1},
+        "regime": "balanced",
+        "state": {"last_action": "SHORT", "decision_steps": 0},
+        "risk_ctx": {},
+    }
+
+    action_int, meta_int = decide(cfg=cfg_int, **kwargs)
+    action_str, meta_str = decide(cfg=cfg_str, **kwargs)
+
+    assert action_int == action_str == "LONG"
+    assert meta_int.get("reasons") == meta_str.get("reasons")
+
+
+def test_decide_preserves_finite_atr_period_string_behavior() -> None:
+    cfg_int = {
+        "thresholds": {
+            "entry_conf_overall": 0.7,
+            "signal_adaptation": {
+                "atr_period": 1,
+                "zones": {
+                    "high": {
+                        "entry_conf_overall": 0.9,
+                    }
+                },
+            },
+        },
+        "risk": {"risk_map": [[0.7, 0.01]]},
+        "gates": {"cooldown_bars": 0},
+    }
+    cfg_str = deepcopy(cfg_int)
+    cfg_str["thresholds"]["signal_adaptation"]["atr_period"] = "1"
+
+    kwargs = {
+        "policy": {},
+        "probas": {"buy": 0.85, "sell": 0.1},
+        "confidence": {"buy": 0.95, "sell": 0.1},
+        "regime": "balanced",
+        "state": {
+            "current_atr": 2.0,
+            "atr_percentiles": {
+                "1": {"p40": 0.5, "p80": 1.0},
+            },
+        },
+        "risk_ctx": {},
+    }
+
+    action_int, meta_int = decide(cfg=cfg_int, **kwargs)
+    action_str, meta_str = decide(cfg=cfg_str, **kwargs)
+
+    assert action_int == action_str == "NONE"
+    assert meta_int.get("reasons") == meta_str.get("reasons")
+
+
+def test_decide_preserves_finite_decision_steps_string_behavior() -> None:
+    cfg = {
+        "thresholds": {"entry_conf_overall": 0.7, "regime_proba": {"balanced": 0.7}},
+        "risk": {"risk_map": [[0.7, 0.01]]},
+        "gates": {"cooldown_bars": 0, "hysteresis_steps": 2},
+    }
+
+    kwargs = {
+        "policy": {},
+        "probas": {"buy": 0.8, "sell": 0.1},
+        "confidence": {"buy": 0.8, "sell": 0.1},
+        "regime": "balanced",
+        "risk_ctx": {},
+        "cfg": cfg,
+    }
+
+    action_int, meta_int = decide(
+        state={"last_action": "SHORT", "decision_steps": 1},
+        **kwargs,
+    )
+    action_str, meta_str = decide(
+        state={"last_action": "SHORT", "decision_steps": "1"},
+        **kwargs,
+    )
+
+    assert action_int == action_str == "LONG"
+    assert meta_int.get("reasons") == meta_str.get("reasons")
+
+
+def test_decide_preserves_finite_cooldown_remaining_string_behavior() -> None:
+    cfg = {
+        "thresholds": {"entry_conf_overall": 0.7, "regime_proba": {"balanced": 0.7}},
+        "risk": {"risk_map": [[0.7, 0.01]]},
+        "gates": {"cooldown_bars": 0},
+    }
+
+    kwargs = {
+        "policy": {},
+        "probas": {"buy": 0.8, "sell": 0.1},
+        "confidence": {"buy": 0.8, "sell": 0.1},
+        "regime": "balanced",
+        "risk_ctx": {},
+        "cfg": cfg,
+    }
+
+    action_int, meta_int = decide(
+        state={"cooldown_remaining": 1},
+        **kwargs,
+    )
+    action_str, meta_str = decide(
+        state={"cooldown_remaining": "1"},
+        **kwargs,
+    )
+
+    assert action_int == action_str == "NONE"
+    assert meta_int.get("reasons") == meta_str.get("reasons")
+    assert "COOLDOWN_ACTIVE" in (meta_str.get("reasons") or [])
+
+
+@pytest.mark.parametrize(
+    "raw_confidence",
+    [float("nan"), float("inf"), float("-inf"), "nan", "inf", "-inf"],
+)
+def test_decide_non_finite_confidence_matches_invalid_path(raw_confidence: object) -> None:
+    cfg = {
+        "thresholds": {"entry_conf_overall": 0.7, "regime_proba": {"balanced": 0.7}},
+        "risk": {"risk_map": [[0.7, 0.01]]},
+        "gates": {"cooldown_bars": 0},
+    }
+
+    baseline_action, baseline_meta = decide(
+        {},
+        probas={"buy": 0.8, "sell": 0.1},
+        confidence={"buy": None, "sell": 0.1},
+        regime="balanced",
+        state={},
+        risk_ctx={},
+        cfg=cfg,
+    )
+    action, meta = decide(
+        {},
+        probas={"buy": 0.8, "sell": 0.1},
+        confidence={"buy": raw_confidence, "sell": 0.1},
+        regime="balanced",
+        state={},
+        risk_ctx={},
+        cfg=cfg,
+    )
+
+    assert baseline_action == action == "NONE"
+    assert baseline_meta.get("reasons") == meta.get("reasons")
+    assert "CONF_TOO_LOW" in (meta.get("reasons") or [])
+
+
+@pytest.mark.parametrize(
+    "raw_hysteresis_steps",
+    [float("nan"), float("inf"), float("-inf"), "nan", "inf", "-inf"],
+)
+def test_decide_non_finite_hysteresis_matches_default_path(raw_hysteresis_steps: object) -> None:
+    cfg_default = {
+        "thresholds": {"entry_conf_overall": 0.7, "regime_proba": {"balanced": 0.7}},
+        "risk": {"risk_map": [[0.7, 0.01]]},
+        "gates": {"cooldown_bars": 0},
+    }
+    cfg_non_finite = deepcopy(cfg_default)
+    cfg_non_finite["gates"]["hysteresis_steps"] = raw_hysteresis_steps
+
+    kwargs = {
+        "policy": {},
+        "probas": {"buy": 0.8, "sell": 0.1},
+        "confidence": {"buy": 0.8, "sell": 0.1},
+        "regime": "balanced",
+        "state": {"last_action": "SHORT", "decision_steps": 0},
+        "risk_ctx": {},
+    }
+
+    baseline_action, baseline_meta = decide(cfg=cfg_default, **kwargs)
+    action, meta = decide(cfg=cfg_non_finite, **kwargs)
+
+    assert baseline_action == action == "NONE"
+    assert baseline_meta.get("reasons") == meta.get("reasons")
+    assert "HYST_WAIT" in (meta.get("reasons") or [])
+
+
 def test_clarity_score_v2_on_round_policy_tie_half_even_deterministic() -> None:
     cfg_off = {
         "ev": {"R_default": 1.0},

--- a/tests/utils/test_decision.py
+++ b/tests/utils/test_decision.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 import pytest
 
 from core.strategy.decision import decide
+from core.strategy.decision_gates import safe_float
 
 
 def test_decide_stub_shapes():
@@ -250,6 +251,10 @@ def test_decide_handles_non_numeric_confidence_without_typeerror() -> None:
 
     assert action == "NONE"
     assert "CONF_TOO_LOW" in (meta.get("reasons") or [])
+
+
+def test_safe_float_returns_default_for_overflowing_int_input() -> None:
+    assert safe_float(10**1000, 1.5) == pytest.approx(1.5)
 
 
 def test_decide_preserves_finite_hysteresis_string_behavior() -> None:


### PR DESCRIPTION
## Governance Packet

- Category: `security | docs | tooling | refactor(server) | api | obs`
- Mode: `STRICT | RESEARCH | SANDBOX` (+ source)
- Risk: `LOW | MED | HIGH`
- Required path: `Quick | Full`
- Scope IN:
- Scope OUT:
- Constraints (default): `NO BEHAVIOR CHANGE`
- Behavior-change exception (if any):

## Gates

### PRE

- [ ] pre-commit/lint
- [ ] smoke tests
- [ ] determinism replay
- [ ] feature cache invariance
- [ ] pipeline invariant

### POST

- [ ] pre-commit/lint
- [ ] smoke tests
- [ ] determinism replay
- [ ] feature cache invariance
- [ ] pipeline invariant

## Skill Usage

- Skills referenced:
- Skills executed:
- Skill proposals (if any):
- Skill updates (if any):

## Evidence

- Base SHA:
- Head SHA:
- Changed files:
- Selectors/commands run:
- Artifacts/links:

## READY_FOR_REVIEW checklist

- [ ] Mode/risk/path documented
- [ ] Scope IN/OUT documented
- [ ] Exact gates + outcomes documented
- [ ] Relevant selectors/artifacts attached

## Summary by Sourcery

Förstärk numerisk hantering i besluts- och EV‑grindlogik, skärp felsemantiken för runtime‑konfigurationens `propose`, lägg till ett deterministiskt manifest till evidensutdata från execution proxy, och introducera styrdokument och runbooks som kodifierar lane‑tillstånd, gränser för live‑uppdatering av runtime‑konfiguration samt praxis för evidenskrav.

New Features:
- Exponera en grov, stabil fel­detalj `non_whitelisted_field` för avvisningar av skyddade anrop till `/config/runtime/propose`, samtidigt som omfattningen av whitelist förblir oförändrad.
- Emittera en deterministisk manifestfil tillsammans med evidensutdata från execution proxy, som fångar in‑hashar, godkänd utdata‑inventering och icke‑egna utdata‑hashar för reproducerbarhet.

Bug Fixes:
- Säkerställ att beslutsgrindar behandlar icke‑ändliga numeriska indata defensivt som standard, samtidigt som beteendet för giltiga ändliga konfigurations‑ och tillståndsvärden bevaras.
- Gör EV‑grindhantering fail‑closed för icke‑ändliga förväntade värden såsom NaN och positiv oändlighet, samtidigt som beteendet för ändliga EV och veto‑semantiken för negativ oändlighet förblir oförändrade.

Enhancements:
- Klargör och förstärk beteendet för runtime‑konfiguration genom att dokumentera att `validate` täcker schemastruktur medan `propose` upprätthåller en snävare whitelist för live‑skrivning, och genom att fortsätta blockera live‑ändring av fält som är schema‑giltiga men inte whitelistade.
- Stärk tester kring besluts‑ och EV‑grindar, config‑API:t och beteendet hos evidens från execution proxy, inklusive paritet mellan sträng och int, hantering av icke‑ändliga tal samt semantik för versionskonflikt och patchar med icke‑whitelistade fält.

Documentation:
- Lägg till styrnings‑ och analysdokument som definierar en plan för premortem‑uppföljningsfas, ett index över aktiva lanes, en matris för live‑uppdatering av runtime‑konfiguration, evidenskravs‑rubriker och adoptionsregler samt flera smala pre‑code‑paket för beslutsgrindar, EV‑grind, config `propose`‑fel och manifest för evidens från execution proxy.

Tests:
- Utöka enhets‑, integrations‑ och backtest‑tester för att täcka paritet mellan ändliga och icke‑ändliga numeriska värden i besluts‑ och EV‑grindar, explicita fel­svar för icke‑whitelistade fält i runtime‑konfigurationsförslag samt repeterbara evidensutdata från execution proxy som inkluderar manifest.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden numeric handling in decision and EV gate logic, tighten runtime config propose error semantics, add a deterministic manifest to execution proxy evidence outputs, and introduce governance docs and runbooks that codify lane state, runtime config live-update boundaries, and evidence claim practices.

New Features:
- Expose a coarse, stable `non_whitelisted_field` error detail for guarded `/config/runtime/propose` rejections while keeping whitelist scope unchanged.
- Emit a deterministic manifest file alongside execution proxy evidence outputs, capturing input hashes, approved output inventory, and non-self output hashes for reproducibility.

Bug Fixes:
- Ensure decision gating treats non-finite numeric inputs defensively by default while preserving behavior for valid finite configuration and state values.
- Make EV gate handling fail-closed for non-finite expected values such as NaN and positive infinity, while keeping finite EV behavior and negative infinity veto semantics unchanged.

Enhancements:
- Clarify and harden runtime config behavior by documenting that `validate` covers schema shape while `propose` enforces a narrower live-write whitelist, and by keeping schema-valid but non-whitelisted fields live-blocked.
- Strengthen tests around decision, EV gate, config API, and execution proxy evidence behavior, including string vs int parity, non-finite numeric handling, and version-conflict / non-whitelisted patch semantics.

Documentation:
- Add governance and analysis documents that define a premortem follow-up phase plan, an active lane index, a runtime config live-update matrix, evidence-claim headers and adoption rules, and multiple narrow pre-code packets for decision gates, EV gate, config propose errors, and execution proxy evidence manifests.

Tests:
- Extend unit, integration, and backtest tests to cover finite vs non-finite numeric parity in decision and EV gates, explicit non-whitelisted error responses for runtime config proposals, and repeatable manifest-bearing execution proxy evidence outputs.

</details>