### PR TITLE
docs: adopt research infrastructure usage contract

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,6 +28,8 @@ Read this file in the following order:
 - Trivial changes may use the quick path below, but must escalate to full protocol if any uncertainty appears.
 - `docs/governance/README.md` is a supplemental operational index and must not override SSOT precedence in this file.
 - For repository layout and file placement guidance, also see `docs/repository-layout-policy.md`. It is a subordinate practical reference and must not override higher-order governance or mode documents.
+- For research/experiment infrastructure usage boundaries, also see `docs/contracts/research_experiment_infrastructure_inventory_contract.md`.
+- Unless explicitly promoted through the current authority path, treat `research_ledger`, `research_orchestrator`, findings bundles/indexes, and `results/research/**` outputs as non-authorizing research/evidence surfaces.
 
 ## Terminology note
 


### PR DESCRIPTION
## Summary
- add a short routing reference in `.github/copilot-instructions.md` to `docs/contracts/research_experiment_infrastructure_inventory_contract.md`
- state that `research_ledger`, `research_orchestrator`, findings bundles/indexes, and `results/research/**` outputs remain non-authorizing research/evidence surfaces unless explicitly promoted through the current authority path

## Notes
- separate follow-up to merged PR #101
- only `.github/copilot-instructions.md` changed
- no changes to `AGENTS.md`, `docs/governance_mode.md`, `docs/knowledge/KNOWLEDGE_AUTHORITY_RULES.md`, runtime, config, tests, or artifacts

## Summary by Sourcery

Förtydliga gränserna för användning av forsknings- och experimentinfrastruktur i styrningsinstruktionerna för Copilot.

Dokumentation:
- Hänvisa till kontraktet för inventering av forsknings- och experimentinfrastruktur från Copilot-instruktionerna.
- Definiera att forskningsrelaterade liggare, orkestratorer, fyndbuntar/-index och resultatutdata är icke-auktoriserande evidensytor om de inte uttryckligen har främjats via auktoritetsvägen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify research and experiment infrastructure usage boundaries in the Copilot governance instructions.

Documentation:
- Reference the research experiment infrastructure inventory contract from the Copilot instructions.
- Define that research-related ledgers, orchestrators, findings bundles/indexes, and results outputs are non-authorizing evidence surfaces unless explicitly promoted via the authority path.

</details>